### PR TITLE
Add a reminder that Zen-Browser still require userStyles to be enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 
 ## Usage
 
-1. [Create a `chrome` folder](https://www.userchrome.org/how-create-userchrome-css.html) in your Zen Browser's profile directory.
+1. [Create a `chrome` folder](https://www.userchrome.org/how-create-userchrome-css.html) in your Zen Browser's profile directory and configure it to enable userstyles.
 2. Copy the `userChrome.css`, `userContent.css`, and `zen-logo.svg` files of your preferred theme from the [`themes/`](themes/) directory in this repository to your `chrome` folder.
 
 > [!NOTE]


### PR DESCRIPTION
I know that's why the first step includes a link to a full guide on setting it up, but the original wording made me think that Zen Browser already had this setting enabled by default (especially when it automatically creates one for Zen Browser mods). I could have worded this pull request as an extra step to make sure you have the correct `about:config` setting enabled, but it was redundant for anyone who followed the linked guide fully.