### PR TITLE
add #historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow stylings

### DIFF
--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -40,6 +40,10 @@ whiskers:
     color: #{{ mantle.hex }} !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #{{ palette[accent].hex }} !important;
+		--swipe-nav-icon-accent-color: #{{ base.hex }}!important;
+	}
   .sidebar-placesTree {
     background-color: #{{ base.hex }} !important;
   }

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #8caaee !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Flamingo/userChrome.css
+++ b/themes/Frappe/Flamingo/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #eebebe !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Green/userChrome.css
+++ b/themes/Frappe/Green/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #a6d189 !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Lavender/userChrome.css
+++ b/themes/Frappe/Lavender/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #babbf1 !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Maroon/userChrome.css
+++ b/themes/Frappe/Maroon/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #ea999c !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Mauve/userChrome.css
+++ b/themes/Frappe/Mauve/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #ca9ee6 !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Peach/userChrome.css
+++ b/themes/Frappe/Peach/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #ef9f76 !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Pink/userChrome.css
+++ b/themes/Frappe/Pink/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f4b8e4 !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Red/userChrome.css
+++ b/themes/Frappe/Red/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #e78284 !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Rosewater/userChrome.css
+++ b/themes/Frappe/Rosewater/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f2d5cf !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Sapphire/userChrome.css
+++ b/themes/Frappe/Sapphire/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #85c1dc !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Sky/userChrome.css
+++ b/themes/Frappe/Sky/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #99d1db !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Teal/userChrome.css
+++ b/themes/Frappe/Teal/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #81c8be !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Yellow/userChrome.css
+++ b/themes/Frappe/Yellow/userChrome.css
@@ -30,6 +30,10 @@
     color: #292c3c !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #e5c890 !important;
+		--swipe-nav-icon-accent-color: #303446!important;
+	}
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Latte/Blue/userChrome.css
+++ b/themes/Latte/Blue/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #1e66f5 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Flamingo/userChrome.css
+++ b/themes/Latte/Flamingo/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #dd7878 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Green/userChrome.css
+++ b/themes/Latte/Green/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #40a02b !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Lavender/userChrome.css
+++ b/themes/Latte/Lavender/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #7287fd !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Maroon/userChrome.css
+++ b/themes/Latte/Maroon/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #e64553 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Mauve/userChrome.css
+++ b/themes/Latte/Mauve/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #8839ef !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Peach/userChrome.css
+++ b/themes/Latte/Peach/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #fe640b !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Pink/userChrome.css
+++ b/themes/Latte/Pink/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #ea76cb !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Red/userChrome.css
+++ b/themes/Latte/Red/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #d20f39 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Rosewater/userChrome.css
+++ b/themes/Latte/Rosewater/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #dc8a78 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Sapphire/userChrome.css
+++ b/themes/Latte/Sapphire/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #209fb5 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Sky/userChrome.css
+++ b/themes/Latte/Sky/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #04a5e5 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Teal/userChrome.css
+++ b/themes/Latte/Teal/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #179299 !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Yellow/userChrome.css
+++ b/themes/Latte/Yellow/userChrome.css
@@ -30,6 +30,10 @@
     color: #e6e9ef !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #df8e1d !important;
+		--swipe-nav-icon-accent-color: #eff1f5!important;
+	}
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Macchiato/Blue/userChrome.css
+++ b/themes/Macchiato/Blue/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #8aadf4 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Flamingo/userChrome.css
+++ b/themes/Macchiato/Flamingo/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f0c6c6 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Green/userChrome.css
+++ b/themes/Macchiato/Green/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #a6da95 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Lavender/userChrome.css
+++ b/themes/Macchiato/Lavender/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #b7bdf8 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Maroon/userChrome.css
+++ b/themes/Macchiato/Maroon/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #ee99a0 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Mauve/userChrome.css
+++ b/themes/Macchiato/Mauve/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #c6a0f6 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Peach/userChrome.css
+++ b/themes/Macchiato/Peach/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f5a97f !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Pink/userChrome.css
+++ b/themes/Macchiato/Pink/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f5bde6 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Red/userChrome.css
+++ b/themes/Macchiato/Red/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #ed8796 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Rosewater/userChrome.css
+++ b/themes/Macchiato/Rosewater/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f4dbd6 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Sapphire/userChrome.css
+++ b/themes/Macchiato/Sapphire/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #7dc4e4 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Sky/userChrome.css
+++ b/themes/Macchiato/Sky/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #91d7e3 !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Teal/userChrome.css
+++ b/themes/Macchiato/Teal/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #8bd5ca !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Yellow/userChrome.css
+++ b/themes/Macchiato/Yellow/userChrome.css
@@ -30,6 +30,10 @@
     color: #1e2030 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #eed49f !important;
+		--swipe-nav-icon-accent-color: #24273a!important;
+	}
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Mocha/Blue/userChrome.css
+++ b/themes/Mocha/Blue/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #89b4fa !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Flamingo/userChrome.css
+++ b/themes/Mocha/Flamingo/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f2cdcd !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Green/userChrome.css
+++ b/themes/Mocha/Green/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #a6e3a1 !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Lavender/userChrome.css
+++ b/themes/Mocha/Lavender/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #b4befe !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Maroon/userChrome.css
+++ b/themes/Mocha/Maroon/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #eba0ac !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #cba6f7 !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Peach/userChrome.css
+++ b/themes/Mocha/Peach/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #fab387 !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Pink/userChrome.css
+++ b/themes/Mocha/Pink/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f5c2e7 !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Red/userChrome.css
+++ b/themes/Mocha/Red/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f38ba8 !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Rosewater/userChrome.css
+++ b/themes/Mocha/Rosewater/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f5e0dc !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Sapphire/userChrome.css
+++ b/themes/Mocha/Sapphire/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #74c7ec !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Sky/userChrome.css
+++ b/themes/Mocha/Sky/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #89dceb !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Teal/userChrome.css
+++ b/themes/Mocha/Teal/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #94e2d5 !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Yellow/userChrome.css
+++ b/themes/Mocha/Yellow/userChrome.css
@@ -30,6 +30,10 @@
     color: #181825 !important;
   }
 
+#historySwipeAnimationPreviousArrow,#historySwipeAnimationNextArrow {
+		--swipe-nav-icon-primary-color: #f9e2af !important;
+		--swipe-nav-icon-accent-color: #1e1e2e!important;
+	}
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }


### PR DESCRIPTION
added stylings that use accent color for the icon that pops up when using the history swipe gesture with track pad. 

from 
<img width="600" height="400" alt="old-zen" src="https://github.com/user-attachments/assets/dfe0d6df-8037-4743-94bc-de3391c1c72e" />
to 
<img width="600" height="400" alt="new-zen" src="https://github.com/user-attachments/assets/a6f66d13-cab9-4848-9bc2-522e308c4bef" />
