### PR TITLE
fix: override Zen Twilight acrylic/blur on wrapper and splitter elements

### DIFF
--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -36,6 +36,14 @@ whiskers:
     --toolbox-bgcolor-inactive: #{{ mantle.hex }} !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #{{ base.hex }} !important;
+    --catppuccin-quit-dialog-fg: #{{ text.hex }} !important;
+    --catppuccin-quit-dialog-accent: #{{ palette[accent].hex }} !important;
+    --catppuccin-quit-dialog-button-bg: #{{ surface0.hex }} !important;
+    --catppuccin-quit-dialog-button-bg-hover: #{{ surface1.hex }} !important;
+    --catppuccin-quit-dialog-button-bg-active: #{{ surface2.hex }} !important;
+    --catppuccin-quit-dialog-button-border: #{{ surface2.hex }} !important;
+    --catppuccin-quit-dialog-muted: #{{ subtext0.hex }} !important;
   }
 
   #permissions-granted-icon {
@@ -227,5 +235,82 @@ whiskers:
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: {{ if(cond=flavor.dark, t="dark", f="light") }} !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -44,6 +44,11 @@ whiskers:
     --catppuccin-quit-dialog-button-bg-active: #{{ surface2.hex }} !important;
     --catppuccin-quit-dialog-button-border: #{{ surface2.hex }} !important;
     --catppuccin-quit-dialog-muted: #{{ subtext0.hex }} !important;
+    --catppuccin-quit-dialog-primary-bg: #{{ palette[accent].hex }} !important;
+    --catppuccin-quit-dialog-primary-bg-hover: color-mix(in srgb, #{{ palette[accent].hex }} 86%, #{{ text.hex }}) !important;
+    --catppuccin-quit-dialog-primary-bg-active: color-mix(in srgb, #{{ palette[accent].hex }} 94%, #{{ base.hex }}) !important;
+    --catppuccin-quit-dialog-primary-border: #{{ palette[accent].hex }} !important;
+    --catppuccin-quit-dialog-primary-fg: #{{ crust.hex }} !important;
   }
 
   #permissions-granted-icon {
@@ -96,6 +101,36 @@ whiskers:
 
   .sidebar-placesTree {
     background-color: #{{ base.hex }} !important;
+  }
+
+  zen-folder {
+    --zen-folder-behind-bgcolor: #{{ surface0.hex }} !important;
+    --zen-folder-front-bgcolor: #{{ surface1.hex }} !important;
+    --zen-folder-stroke: #{{ text.hex }} !important;
+
+    & > .tab-group-label-container .tab-group-folder-icon svg {
+      color: #{{ text.hex }} !important;
+      filter: none !important;
+    }
+
+    & > .tab-group-label-container .tab-group-folder-icon svg :is(.back, .front) {
+      stroke: #{{ text.hex }} !important;
+      stroke-width: 1.4px !important;
+    }
+
+    &:is([selected], [has-active]) {
+      --zen-folder-behind-bgcolor: color-mix(in srgb, #{{ palette[accent].hex }} 18%, #{{ surface0.hex }}) !important;
+      --zen-folder-front-bgcolor: color-mix(in srgb, #{{ palette[accent].hex }} 24%, #{{ surface1.hex }}) !important;
+      --zen-folder-stroke: #{{ palette[accent].hex }} !important;
+
+      & > .tab-group-label-container .tab-group-folder-icon svg {
+        color: #{{ palette[accent].hex }} !important;
+      }
+
+      & > .tab-group-label-container .tab-group-folder-icon svg :is(.back, .front) {
+        stroke: #{{ palette[accent].hex }} !important;
+      }
+    }
   }
 
   #zen-workspaces-button {
@@ -332,24 +367,43 @@ whiskers:
     dialog::part(dialog-button) {
       appearance: none !important;
       -moz-appearance: none !important;
+      -moz-default-appearance: none !important;
       background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-color: var(--catppuccin-quit-dialog-button-bg) !important;
       background-image: none !important;
       color: var(--catppuccin-quit-dialog-fg) !important;
       border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
       border-radius: 10px !important;
-      box-shadow: none !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-button-bg) !important;
       text-shadow: none !important;
       outline: none !important;
     }
 
-    dialog::part(dialog-button):hover {
-      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
-      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    dialog::part(catppuccin-primary-button) {
+      background: var(--catppuccin-quit-dialog-primary-bg) !important;
+      background-color: var(--catppuccin-quit-dialog-primary-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-primary-fg) !important;
+      border-color: var(--catppuccin-quit-dialog-primary-border) !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-primary-bg) !important;
     }
 
-    dialog::part(dialog-button):hover:active {
-      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
-      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    dialog::part(catppuccin-primary-button):hover {
+      background: var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+      background-color: var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-primary-fg) !important;
+      border-color: var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+    }
+
+    dialog::part(catppuccin-primary-button):hover:active {
+      background: var(--catppuccin-quit-dialog-primary-bg-active) !important;
+      background-color: var(--catppuccin-quit-dialog-primary-bg-active) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-primary-fg) !important;
+      border-color: var(--catppuccin-quit-dialog-primary-bg-active) !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-primary-bg-active) !important;
     }
 
     dialog::part(dialog-button):focus-visible {

--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -50,6 +50,50 @@ whiskers:
     color: #{{ mantle.hex }} !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #{{ base.hex }} !important;
+    --sidebar-text-color: #{{ text.hex }} !important;
+    --sidebar-border-color: #{{ base.hex }} !important;
+    --lwt-sidebar-background-color: #{{ base.hex }} !important;
+    --lwt-sidebar-text-color: #{{ text.hex }} !important;
+    background: #{{ base.hex }} !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #{{ base.hex }} !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #{{ base.hex }} !important;
+    --lwt-toolbar-field-focus: #{{ base.hex }} !important;
+    --lwt-toolbar-field-border-color: #{{ base.hex }} !important;
+    border-color: #{{ base.hex }} !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #{{ base.hex }} !important;
+    --sidebar-text-color: #{{ text.hex }} !important;
+    --sidebar-border-color: #{{ base.hex }} !important;
+    background: #{{ base.hex }} !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #{{ base.hex }} !important;
   }

--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -136,7 +136,9 @@ whiskers:
     background-color: #{{ mantle.hex }} !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #{{ mantle.hex }};
@@ -187,6 +189,38 @@ whiskers:
   #main-window {
     background: #{{ mantle.hex }} !important;
     background-color: #{{ mantle.hex }} !important;
+  }
+
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
   }
 
   /* Remove seam shadows that can show through at the sidebar/content corners */

--- a/templates/userChrome.tera
+++ b/templates/userChrome.tera
@@ -34,6 +34,8 @@ whiskers:
     --zen-themed-toolbar-bg: #{{ mantle.hex }} !important;
     --zen-main-browser-background: #{{ mantle.hex }} !important;
     --toolbox-bgcolor-inactive: #{{ mantle.hex }} !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -130,11 +132,66 @@ whiskers:
     --identity-icon-color: #{{ mauve.hex }} !important;
   }
 
-  hbox#titlebar {
+  #zen-appcontent-navbar-container {
     background-color: #{{ mantle.hex }} !important;
   }
 
-  #zen-appcontent-navbar-container {
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #{{ mantle.hex }};
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #{{ mantle.hex }} 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
+
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Wrapper/background painting that proved safe in testing */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #{{ mantle.hex }} !important;
     background-color: #{{ mantle.hex }} !important;
+  }
+
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/templates/userContent.tera
+++ b/templates/userContent.tera
@@ -73,67 +73,326 @@ whiskers:
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #{{ mantle.hex }} !important;
-      --in-content-text-color: #{{ text.hex }} !important;
+      --background-color-canvas: #{{ crust.hex }} !important;
+      --background-color-box: #{{ base.hex }} !important;
+      --background-color-box-info: #{{ surface0.hex }} !important;
+      --background-color-critical: color-mix(in srgb, #{{ red.hex }} 18%, #{{ base.hex }}) !important;
+      --background-color-information: color-mix(in srgb, #{{ blue.hex }} 18%, #{{ base.hex }}) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #{{ palette[accent].hex }} 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #{{ palette[accent].hex }} 26%, #{{ surface0.hex }}) !important;
+      --background-color-success: color-mix(in srgb, #{{ green.hex }} 18%, #{{ base.hex }}) !important;
+      --background-color-warning: color-mix(in srgb, #{{ yellow.hex }} 18%, #{{ base.hex }}) !important;
+      --border-color: #{{ surface1.hex }} !important;
+      --border-color-deemphasized: #{{ surface0.hex }} !important;
+      --border-color-interactive: #{{ surface2.hex }} !important;
+      --border-color-interactive-hover: #{{ overlay0.hex }} !important;
+      --border-color-interactive-active: #{{ overlay1.hex }} !important;
+      --border-color-selected: #{{ palette[accent].hex }} !important;
+      --box-background-color: #{{ base.hex }} !important;
+      --box-border-color: #{{ surface1.hex }} !important;
+      --box-button-background-color: #{{ surface0.hex }} !important;
+      --box-button-background-color-hover: #{{ surface1.hex }} !important;
+      --box-button-background-color-active: #{{ surface2.hex }} !important;
+      --box-button-background-color-selected: color-mix(in srgb, #{{ palette[accent].hex }} 24%, #{{ surface0.hex }}) !important;
+      --box-button-text-color: #{{ text.hex }} !important;
+      --box-icon-color: #{{ subtext1.hex }} !important;
+      --button-background-color: #{{ surface0.hex }} !important;
+      --button-background-color-hover: #{{ surface1.hex }} !important;
+      --button-background-color-active: #{{ surface2.hex }} !important;
+      --button-background-color-selected: color-mix(in srgb, #{{ palette[accent].hex }} 24%, #{{ surface0.hex }}) !important;
+      --button-background-color-primary: #{{ palette[accent].hex }} !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #{{ palette[accent].hex }} 86%, #{{ text.hex }}) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #{{ palette[accent].hex }} 94%, #{{ base.hex }}) !important;
+      --button-border-color: #{{ surface1.hex }} !important;
+      --button-border-color-hover: #{{ surface2.hex }} !important;
+      --button-border-color-active: #{{ palette[accent].hex }} !important;
+      --button-border-color-primary: #{{ palette[accent].hex }} !important;
+      --button-text-color: #{{ text.hex }} !important;
+      --button-text-color-hover: #{{ text.hex }} !important;
+      --button-text-color-active: #{{ text.hex }} !important;
+      --button-text-color-primary: #{{ crust.hex }} !important;
+      --button-text-color-primary-hover: #{{ crust.hex }} !important;
+      --button-text-color-primary-active: #{{ crust.hex }} !important;
+      --card-background-color: #{{ base.hex }} !important;
+      --card-border-color: #{{ surface1.hex }} !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #{{ surface2.hex }} !important;
+      --color-accent-primary: #{{ palette[accent].hex }} !important;
+      --color-accent-primary-hover: {{ palette[accent] | add(lightness=5) | css_rgb }} !important;
+      --color-accent-primary-active: {{ palette[accent] | add(hue=15) | css_rgb}} !important;
+      --focus-outline-color: #{{ palette[accent].hex }} !important;
+      --icon-color: #{{ subtext1.hex }} !important;
+      --icon-color-critical: #{{ red.hex }} !important;
+      --icon-color-information: #{{ blue.hex }} !important;
+      --icon-color-success: #{{ green.hex }} !important;
+      --icon-color-warning: #{{ yellow.hex }} !important;
+      --input-text-background-color: #{{ mantle.hex }} !important;
+      --input-text-border-color: #{{ surface2.hex }} !important;
+      --input-text-color: #{{ text.hex }} !important;
+      --input-text-placeholder-color: #{{ subtext0.hex }} !important;
       --link-color: #{{ palette[accent].hex }} !important;
+      --link-color-active: {{ palette[accent] | add(hue=15) | css_rgb}} !important;
       --link-color-hover: {{ palette[accent] | add(lightness=5) | css_rgb }} !important;
-      --zen-colors-primary: #{{ surface0.hex }} !important;
+      --link-color-visited: #{{ mauve.hex }} !important;
+      --select-background-color: #{{ surface0.hex }} !important;
+      --select-background-color-hover: #{{ surface1.hex }} !important;
+      --select-background-color-active: #{{ surface2.hex }} !important;
+      --select-border-color: #{{ surface1.hex }} !important;
+      --select-border-color-hover: #{{ surface2.hex }} !important;
+      --select-border-color-active: #{{ palette[accent].hex }} !important;
+      --select-text-color: #{{ text.hex }} !important;
+      --table-row-background-color-alternate: #{{ mantle.hex }} !important;
+      --table-row-background-color-hover: #{{ surface0.hex }} !important;
+      --table-row-background-color-selected: color-mix(in srgb, #{{ palette[accent].hex }} 24%, #{{ surface0.hex }}) !important;
+      --text-color: #{{ text.hex }} !important;
+      --text-color-deemphasized: #{{ subtext1.hex }} !important;
+      --text-color-disabled: #{{ overlay0.hex }} !important;
+      --text-color-error: #{{ red.hex }} !important;
+      --text-color-success: #{{ green.hex }} !important;
+      --text-color-warning: #{{ yellow.hex }} !important;
+      --toggle-background-color: #{{ surface1.hex }} !important;
+      --toggle-background-color-hover: #{{ surface2.hex }} !important;
+      --toggle-background-color-pressed: #{{ palette[accent].hex }} !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #{{ palette[accent].hex }} 86%, #{{ text.hex }}) !important;
+      --toggle-dot-background-color: #{{ text.hex }} !important;
+      --toggle-dot-background-color-on-pressed: #{{ crust.hex }} !important;
+      --visual-picker-item-background-color: #{{ base.hex }} !important;
+      --visual-picker-item-background-color-hover: #{{ surface0.hex }} !important;
+      --visual-picker-item-background-color-active: #{{ surface1.hex }} !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #{{ palette[accent].hex }} 16%, #{{ surface0.hex }}) !important;
+      --visual-picker-item-border-color: #{{ surface1.hex }} !important;
+      --visual-picker-item-border-color-hover: #{{ surface2.hex }} !important;
+      --visual-picker-item-border-color-selected: #{{ palette[accent].hex }} !important;
+      --visual-picker-item-check-icon-color: #{{ crust.hex }} !important;
+      --visual-picker-item-icon-color: #{{ subtext1.hex }} !important;
+      --visual-picker-item-text-color: #{{ text.hex }} !important;
+      --zen-colors-tertiary: #{{ mantle.hex }} !important;
+      --zen-colors-border: #{{ surface1.hex }} !important;
+      --zen-colors-hover-bg: #{{ surface0.hex }} !important;
+      --in-content-text-color: #{{ text.hex }} !important;
+      --in-content-page-background: #{{ crust.hex }} !important;
+      --in-content-page-color: #{{ text.hex }} !important;
       --in-content-box-background: #{{ surface0.hex }} !important;
+      --in-content-box-background-odd: #{{ mantle.hex }} !important;
+      --in-content-box-border-color: #{{ surface1.hex }} !important;
+      --in-content-border-color: #{{ surface1.hex }} !important;
+      --in-content-button-background: #{{ surface0.hex }} !important;
+      --in-content-button-background-hover: #{{ surface1.hex }} !important;
+      --in-content-button-background-active: #{{ surface2.hex }} !important;
+      --in-content-button-border-color: #{{ surface1.hex }} !important;
+      --in-content-button-border-color-hover: #{{ surface2.hex }} !important;
+      --in-content-button-border-color-active: #{{ palette[accent].hex }} !important;
+      --in-content-button-text-color: #{{ text.hex }} !important;
+      --in-content-deemphasized-text: #{{ subtext1.hex }} !important;
+      --in-content-item-hover: #{{ surface0.hex }} !important;
+      --in-content-item-selected: color-mix(in srgb, #{{ palette[accent].hex }} 22%, #{{ surface0.hex }}) !important;
+      --in-content-primary-button-background: #{{ palette[accent].hex }} !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #{{ palette[accent].hex }} 86%, #{{ text.hex }}) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #{{ palette[accent].hex }} 94%, #{{ base.hex }}) !important;
+      --in-content-primary-button-text-color: #{{ crust.hex }} !important;
+      --zen-colors-primary: #{{ surface0.hex }} !important;
       --zen-primary-color: #{{ palette[accent].hex }} !important;
     }
 
-    groupbox , moz-card{
-      background: #{{ base.hex }} !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #{{ surface0.hex }} !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #{{ crust.hex }} !important;
       color: #{{ text.hex }} !important;
     }
 
-    .main-content {
-      background-color: #{{ crust.hex }} !important;
+    .navigation {
+      background: #{{ mantle.hex }} !important;
+      color: #{{ text.hex }} !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #{{ surface0.hex }} !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #{{ palette[accent].hex }} !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #{{ base.hex }} !important;
+      border: 1px solid #{{ surface1.hex }} !important;
+      box-shadow: none !important;
+      color: #{{ text.hex }} !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #{{ base.hex }} !important;
+      --card-border-color: #{{ surface1.hex }} !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #{{ surface2.hex }} !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #{{ base.hex }} !important;
+      --box-border-color: #{{ surface1.hex }} !important;
+      --box-button-background-color: #{{ surface0.hex }} !important;
+      --box-button-background-color-hover: #{{ surface1.hex }} !important;
+      --box-button-background-color-active: #{{ surface2.hex }} !important;
+      --box-button-text-color: #{{ text.hex }} !important;
+      --box-icon-color: #{{ subtext1.hex }} !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #{{ mantle.hex }} !important;
+      --input-text-border-color: #{{ surface2.hex }} !important;
+      --input-text-color: #{{ text.hex }} !important;
+      --input-text-placeholder-color: #{{ subtext0.hex }} !important;
+      --select-background-color: #{{ surface0.hex }} !important;
+      --select-background-color-hover: #{{ surface1.hex }} !important;
+      --select-background-color-active: #{{ surface2.hex }} !important;
+      --select-border-color: #{{ surface1.hex }} !important;
+      --select-border-color-hover: #{{ surface2.hex }} !important;
+      --select-border-color-active: #{{ palette[accent].hex }} !important;
+      --select-text-color: #{{ text.hex }} !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #{{ surface1.hex }} !important;
+      --toggle-background-color-hover: #{{ surface2.hex }} !important;
+      --toggle-background-color-pressed: #{{ palette[accent].hex }} !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #{{ palette[accent].hex }} 86%, #{{ text.hex }}) !important;
+      --toggle-dot-background-color: #{{ text.hex }} !important;
+      --toggle-dot-background-color-on-pressed: #{{ crust.hex }} !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #{{ base.hex }} !important;
+      --visual-picker-item-background-color-hover: #{{ surface0.hex }} !important;
+      --visual-picker-item-background-color-active: #{{ surface1.hex }} !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #{{ palette[accent].hex }} 16%, #{{ surface0.hex }}) !important;
+      --visual-picker-item-border-color: #{{ surface1.hex }} !important;
+      --visual-picker-item-border-color-hover: #{{ surface2.hex }} !important;
+      --visual-picker-item-border-color-selected: #{{ palette[accent].hex }} !important;
+      --visual-picker-item-check-icon-color: #{{ crust.hex }} !important;
+      --visual-picker-item-icon-color: #{{ subtext1.hex }} !important;
+      --visual-picker-item-text-color: #{{ text.hex }} !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #{{ surface0.hex }} !important;
+      color: #{{ text.hex }} !important;
+      border-color: #{{ surface1.hex }} !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #{{ surface1.hex }} !important;
+      border-color: #{{ surface2.hex }} !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #{{ surface2.hex }} !important;
+      border-color: #{{ palette[accent].hex }} !important;
+    }
+
+    .zenCKSOption-input {
+      background: #{{ surface0.hex }} !important;
+      border-color: #{{ surface1.hex }} !important;
+      color: #{{ text.hex }} !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #{{ surface1.hex }} !important;
+      border-color: #{{ surface2.hex }} !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #{{ mantle.hex }} !important;
+      border-color: #{{ palette[accent].hex }} !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #{{ palette[accent].hex }} 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #{{ surface0.hex }} !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #{{ base.hex }} !important;
+      border-color: #{{ surface1.hex }} !important;
+      color: #{{ text.hex }} !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #{{ surface0.hex }} !important;
+      border-color: #{{ surface2.hex }} !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #{{ surface0.hex }} !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #{{ palette[accent].hex }} !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #{{ blue.hex }} !important;
+      --identity-icon-color: #{{ blue.hex }} !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #{{ teal.hex }} !important;
+      --identity-icon-color: #{{ teal.hex }} !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #{{ green.hex }} !important;
+      --identity-icon-color: #{{ green.hex }} !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #{{ yellow.hex }} !important;
+      --identity-icon-color: #{{ yellow.hex }} !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #{{ peach.hex }} !important;
+      --identity-icon-color: #{{ peach.hex }} !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #{{ red.hex }} !important;
+      --identity-icon-color: #{{ red.hex }} !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #{{ pink.hex }} !important;
+      --identity-icon-color: #{{ pink.hex }} !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #{{ mauve.hex }} !important;
+      --identity-icon-color: #{{ mauve.hex }} !important;
     }
   }
 

--- a/templates/userContent.tera
+++ b/templates/userContent.tera
@@ -212,6 +212,12 @@ whiskers:
       color: #{{ text.hex }} !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #{{ surface0.hex }} !important;
@@ -220,6 +226,7 @@ whiskers:
     #categories > .category[selected],
     #categories > .category.selected {
       color: #{{ palette[accent].hex }} !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #8caaee !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -217,5 +225,82 @@
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -126,7 +126,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -177,6 +179,38 @@
   #main-window {
     background: #292c3c !important;
     background-color: #292c3c !important;
+  }
+
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
   }
 
   /* Remove seam shadows that can show through at the sidebar/content corners */

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -34,6 +34,11 @@
     --catppuccin-quit-dialog-button-bg-active: #626880 !important;
     --catppuccin-quit-dialog-button-border: #626880 !important;
     --catppuccin-quit-dialog-muted: #a5adce !important;
+    --catppuccin-quit-dialog-primary-bg: #8caaee !important;
+    --catppuccin-quit-dialog-primary-bg-hover: color-mix(in srgb, #8caaee 86%, #c6d0f5) !important;
+    --catppuccin-quit-dialog-primary-bg-active: color-mix(in srgb, #8caaee 94%, #303446) !important;
+    --catppuccin-quit-dialog-primary-border: #8caaee !important;
+    --catppuccin-quit-dialog-primary-fg: #232634 !important;
   }
 
   #permissions-granted-icon {
@@ -86,6 +91,36 @@
 
   .sidebar-placesTree {
     background-color: #303446 !important;
+  }
+
+  zen-folder {
+    --zen-folder-behind-bgcolor: #414559 !important;
+    --zen-folder-front-bgcolor: #51576d !important;
+    --zen-folder-stroke: #c6d0f5 !important;
+
+    & > .tab-group-label-container .tab-group-folder-icon svg {
+      color: #c6d0f5 !important;
+      filter: none !important;
+    }
+
+    & > .tab-group-label-container .tab-group-folder-icon svg :is(.back, .front) {
+      stroke: #c6d0f5 !important;
+      stroke-width: 1.4px !important;
+    }
+
+    &:is([selected], [has-active]) {
+      --zen-folder-behind-bgcolor: color-mix(in srgb, #8caaee 18%, #414559) !important;
+      --zen-folder-front-bgcolor: color-mix(in srgb, #8caaee 24%, #51576d) !important;
+      --zen-folder-stroke: #8caaee !important;
+
+      & > .tab-group-label-container .tab-group-folder-icon svg {
+        color: #8caaee !important;
+      }
+
+      & > .tab-group-label-container .tab-group-folder-icon svg :is(.back, .front) {
+        stroke: #8caaee !important;
+      }
+    }
   }
 
   #zen-workspaces-button {
@@ -322,24 +357,43 @@
     dialog::part(dialog-button) {
       appearance: none !important;
       -moz-appearance: none !important;
+      -moz-default-appearance: none !important;
       background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-color: var(--catppuccin-quit-dialog-button-bg) !important;
       background-image: none !important;
       color: var(--catppuccin-quit-dialog-fg) !important;
       border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
       border-radius: 10px !important;
-      box-shadow: none !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-button-bg) !important;
       text-shadow: none !important;
       outline: none !important;
     }
 
-    dialog::part(dialog-button):hover {
-      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
-      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    dialog::part(catppuccin-primary-button) {
+      background: var(--catppuccin-quit-dialog-primary-bg) !important;
+      background-color: var(--catppuccin-quit-dialog-primary-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-primary-fg) !important;
+      border-color: var(--catppuccin-quit-dialog-primary-border) !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-primary-bg) !important;
     }
 
-    dialog::part(dialog-button):hover:active {
-      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
-      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    dialog::part(catppuccin-primary-button):hover {
+      background: var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+      background-color: var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-primary-fg) !important;
+      border-color: var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-primary-bg-hover) !important;
+    }
+
+    dialog::part(catppuccin-primary-button):hover:active {
+      background: var(--catppuccin-quit-dialog-primary-bg-active) !important;
+      background-color: var(--catppuccin-quit-dialog-primary-bg-active) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-primary-fg) !important;
+      border-color: var(--catppuccin-quit-dialog-primary-bg-active) !important;
+      box-shadow: inset 0 0 0 999px var(--catppuccin-quit-dialog-primary-bg-active) !important;
     }
 
     dialog::part(dialog-button):focus-visible {

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Blue/userChrome.css
+++ b/themes/Frappe/Blue/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Blue/userContent.css
+++ b/themes/Frappe/Blue/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #8caaee 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #8caaee 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #8caaee !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #8caaee 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #8caaee 24%, #414559) !important;
+      --button-background-color-primary: #8caaee !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #8caaee 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #8caaee 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #8caaee !important;
+      --button-border-color-primary: #8caaee !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #8caaee !important;
+      --color-accent-primary-hover: rgb(163, 186, 241) !important;
+      --color-accent-primary-active: rgb(140, 145, 238) !important;
+      --focus-outline-color: #8caaee !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #8caaee !important;
+      --link-color-active: rgb(140, 145, 238) !important;
       --link-color-hover: rgb(163, 186, 241) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #8caaee !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #8caaee 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #8caaee !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8caaee 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8caaee 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #8caaee !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #8caaee !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #8caaee 22%, #414559) !important;
+      --in-content-primary-button-background: #8caaee !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #8caaee 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #8caaee 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #8caaee !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #8caaee !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #8caaee !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #8caaee !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8caaee 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8caaee 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #8caaee !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #8caaee !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #8caaee !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #8caaee 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #8caaee !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Blue/userContent.css
+++ b/themes/Frappe/Blue/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #8caaee !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Flamingo/userChrome.css
+++ b/themes/Frappe/Flamingo/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Flamingo/userChrome.css
+++ b/themes/Frappe/Flamingo/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #eebebe !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Flamingo/userChrome.css
+++ b/themes/Frappe/Flamingo/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Flamingo/userChrome.css
+++ b/themes/Frappe/Flamingo/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Flamingo/userContent.css
+++ b/themes/Frappe/Flamingo/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #eebebe 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #eebebe 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #eebebe !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #eebebe 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #eebebe 24%, #414559) !important;
+      --button-background-color-primary: #eebebe !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #eebebe 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #eebebe 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #eebebe !important;
+      --button-border-color-primary: #eebebe !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #eebebe !important;
+      --color-accent-primary-hover: rgb(243, 211, 211) !important;
+      --color-accent-primary-active: rgb(238, 202, 190) !important;
+      --focus-outline-color: #eebebe !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #eebebe !important;
+      --link-color-active: rgb(238, 202, 190) !important;
       --link-color-hover: rgb(243, 211, 211) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #eebebe !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #eebebe 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #eebebe !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #eebebe 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #eebebe 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #eebebe !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #eebebe !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #eebebe 22%, #414559) !important;
+      --in-content-primary-button-background: #eebebe !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #eebebe 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #eebebe 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #eebebe !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #eebebe !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #eebebe !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #eebebe !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #eebebe 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #eebebe 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #eebebe !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #eebebe !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #eebebe !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #eebebe 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #eebebe !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Flamingo/userContent.css
+++ b/themes/Frappe/Flamingo/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #eebebe !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Green/userChrome.css
+++ b/themes/Frappe/Green/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Green/userChrome.css
+++ b/themes/Frappe/Green/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #a6d189 !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Green/userChrome.css
+++ b/themes/Frappe/Green/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Green/userChrome.css
+++ b/themes/Frappe/Green/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Green/userContent.css
+++ b/themes/Frappe/Green/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #a6d189 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Green/userContent.css
+++ b/themes/Frappe/Green/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #a6d189 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #a6d189 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #a6d189 !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #a6d189 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #a6d189 24%, #414559) !important;
+      --button-background-color-primary: #a6d189 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #a6d189 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #a6d189 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #a6d189 !important;
+      --button-border-color-primary: #a6d189 !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #a6d189 !important;
+      --color-accent-primary-hover: rgb(180, 216, 156) !important;
+      --color-accent-primary-active: rgb(148, 209, 137) !important;
+      --focus-outline-color: #a6d189 !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #a6d189 !important;
+      --link-color-active: rgb(148, 209, 137) !important;
       --link-color-hover: rgb(180, 216, 156) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #a6d189 !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #a6d189 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #a6d189 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #a6d189 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #a6d189 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #a6d189 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #a6d189 !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #a6d189 22%, #414559) !important;
+      --in-content-primary-button-background: #a6d189 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #a6d189 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #a6d189 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #a6d189 !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #a6d189 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #a6d189 !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #a6d189 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #a6d189 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #a6d189 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #a6d189 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #a6d189 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #a6d189 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #a6d189 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #a6d189 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Lavender/userChrome.css
+++ b/themes/Frappe/Lavender/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Lavender/userChrome.css
+++ b/themes/Frappe/Lavender/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #babbf1 !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Lavender/userChrome.css
+++ b/themes/Frappe/Lavender/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Lavender/userChrome.css
+++ b/themes/Frappe/Lavender/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Lavender/userContent.css
+++ b/themes/Frappe/Lavender/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #babbf1 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #babbf1 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #babbf1 !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #babbf1 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #babbf1 24%, #414559) !important;
+      --button-background-color-primary: #babbf1 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #babbf1 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #babbf1 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #babbf1 !important;
+      --button-border-color-primary: #babbf1 !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #babbf1 !important;
+      --color-accent-primary-hover: rgb(208, 209, 246) !important;
+      --color-accent-primary-active: rgb(200, 187, 241) !important;
+      --focus-outline-color: #babbf1 !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #babbf1 !important;
+      --link-color-active: rgb(200, 187, 241) !important;
       --link-color-hover: rgb(208, 209, 246) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #babbf1 !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #babbf1 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #babbf1 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #babbf1 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #babbf1 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #babbf1 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #babbf1 !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #babbf1 22%, #414559) !important;
+      --in-content-primary-button-background: #babbf1 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #babbf1 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #babbf1 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #babbf1 !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #babbf1 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #babbf1 !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #babbf1 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #babbf1 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #babbf1 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #babbf1 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #babbf1 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #babbf1 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #babbf1 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #babbf1 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Lavender/userContent.css
+++ b/themes/Frappe/Lavender/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #babbf1 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Maroon/userChrome.css
+++ b/themes/Frappe/Maroon/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #ea999c !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Maroon/userChrome.css
+++ b/themes/Frappe/Maroon/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Maroon/userChrome.css
+++ b/themes/Frappe/Maroon/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Maroon/userChrome.css
+++ b/themes/Frappe/Maroon/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Maroon/userContent.css
+++ b/themes/Frappe/Maroon/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #ea999c !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Maroon/userContent.css
+++ b/themes/Frappe/Maroon/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #ea999c 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #ea999c 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #ea999c !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #ea999c 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #ea999c 24%, #414559) !important;
+      --button-background-color-primary: #ea999c !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #ea999c 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #ea999c 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #ea999c !important;
+      --button-border-color-primary: #ea999c !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #ea999c !important;
+      --color-accent-primary-hover: rgb(239, 175, 177) !important;
+      --color-accent-primary-active: rgb(234, 171, 154) !important;
+      --focus-outline-color: #ea999c !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #ea999c !important;
+      --link-color-active: rgb(234, 171, 154) !important;
       --link-color-hover: rgb(239, 175, 177) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #ea999c !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #ea999c 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #ea999c !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ea999c 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ea999c 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #ea999c !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #ea999c !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #ea999c 22%, #414559) !important;
+      --in-content-primary-button-background: #ea999c !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #ea999c 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #ea999c 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #ea999c !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #ea999c !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #ea999c !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #ea999c !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ea999c 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ea999c 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #ea999c !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #ea999c !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #ea999c !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #ea999c 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #ea999c !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Mauve/userChrome.css
+++ b/themes/Frappe/Mauve/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Mauve/userChrome.css
+++ b/themes/Frappe/Mauve/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #ca9ee6 !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Mauve/userChrome.css
+++ b/themes/Frappe/Mauve/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Mauve/userChrome.css
+++ b/themes/Frappe/Mauve/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Mauve/userContent.css
+++ b/themes/Frappe/Mauve/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #ca9ee6 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #ca9ee6 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #ca9ee6 !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #ca9ee6 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #ca9ee6 24%, #414559) !important;
+      --button-background-color-primary: #ca9ee6 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #ca9ee6 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #ca9ee6 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #ca9ee6 !important;
+      --button-border-color-primary: #ca9ee6 !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #ca9ee6 !important;
+      --color-accent-primary-hover: rgb(214, 179, 235) !important;
+      --color-accent-primary-active: rgb(220, 158, 230) !important;
+      --focus-outline-color: #ca9ee6 !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #ca9ee6 !important;
+      --link-color-active: rgb(220, 158, 230) !important;
       --link-color-hover: rgb(214, 179, 235) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #ca9ee6 !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #ca9ee6 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #ca9ee6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ca9ee6 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ca9ee6 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #ca9ee6 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #ca9ee6 !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #ca9ee6 22%, #414559) !important;
+      --in-content-primary-button-background: #ca9ee6 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #ca9ee6 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #ca9ee6 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #ca9ee6 !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #ca9ee6 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #ca9ee6 !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #ca9ee6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ca9ee6 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ca9ee6 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #ca9ee6 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #ca9ee6 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #ca9ee6 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #ca9ee6 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #ca9ee6 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Mauve/userContent.css
+++ b/themes/Frappe/Mauve/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #ca9ee6 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Peach/userChrome.css
+++ b/themes/Frappe/Peach/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Peach/userChrome.css
+++ b/themes/Frappe/Peach/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #ef9f76 !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Peach/userChrome.css
+++ b/themes/Frappe/Peach/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Peach/userChrome.css
+++ b/themes/Frappe/Peach/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Peach/userContent.css
+++ b/themes/Frappe/Peach/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #ef9f76 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Peach/userContent.css
+++ b/themes/Frappe/Peach/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #ef9f76 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #ef9f76 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #ef9f76 !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #ef9f76 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #ef9f76 24%, #414559) !important;
+      --button-background-color-primary: #ef9f76 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #ef9f76 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #ef9f76 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #ef9f76 !important;
+      --button-border-color-primary: #ef9f76 !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #ef9f76 !important;
+      --color-accent-primary-hover: rgb(242, 175, 142) !important;
+      --color-accent-primary-active: rgb(239, 189, 119) !important;
+      --focus-outline-color: #ef9f76 !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #ef9f76 !important;
+      --link-color-active: rgb(239, 189, 119) !important;
       --link-color-hover: rgb(242, 175, 142) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #ef9f76 !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #ef9f76 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #ef9f76 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ef9f76 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ef9f76 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #ef9f76 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #ef9f76 !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #ef9f76 22%, #414559) !important;
+      --in-content-primary-button-background: #ef9f76 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #ef9f76 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #ef9f76 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #ef9f76 !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #ef9f76 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #ef9f76 !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #ef9f76 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ef9f76 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ef9f76 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #ef9f76 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #ef9f76 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #ef9f76 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #ef9f76 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #ef9f76 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Pink/userChrome.css
+++ b/themes/Frappe/Pink/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Pink/userChrome.css
+++ b/themes/Frappe/Pink/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #f4b8e4 !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Pink/userChrome.css
+++ b/themes/Frappe/Pink/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Pink/userChrome.css
+++ b/themes/Frappe/Pink/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Pink/userContent.css
+++ b/themes/Frappe/Pink/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f4b8e4 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Pink/userContent.css
+++ b/themes/Frappe/Pink/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f4b8e4 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f4b8e4 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #f4b8e4 !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f4b8e4 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #f4b8e4 24%, #414559) !important;
+      --button-background-color-primary: #f4b8e4 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f4b8e4 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f4b8e4 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #f4b8e4 !important;
+      --button-border-color-primary: #f4b8e4 !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #f4b8e4 !important;
+      --color-accent-primary-hover: rgb(248, 206, 237) !important;
+      --color-accent-primary-active: rgb(244, 184, 213) !important;
+      --focus-outline-color: #f4b8e4 !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #f4b8e4 !important;
+      --link-color-active: rgb(244, 184, 213) !important;
       --link-color-hover: rgb(248, 206, 237) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #f4b8e4 !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f4b8e4 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #f4b8e4 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f4b8e4 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f4b8e4 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #f4b8e4 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #f4b8e4 !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #f4b8e4 22%, #414559) !important;
+      --in-content-primary-button-background: #f4b8e4 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f4b8e4 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f4b8e4 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #f4b8e4 !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f4b8e4 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #f4b8e4 !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #f4b8e4 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f4b8e4 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f4b8e4 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #f4b8e4 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #f4b8e4 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #f4b8e4 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f4b8e4 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f4b8e4 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Red/userChrome.css
+++ b/themes/Frappe/Red/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Red/userChrome.css
+++ b/themes/Frappe/Red/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #e78284 !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Red/userChrome.css
+++ b/themes/Frappe/Red/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Red/userChrome.css
+++ b/themes/Frappe/Red/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Red/userContent.css
+++ b/themes/Frappe/Red/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #e78284 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Red/userContent.css
+++ b/themes/Frappe/Red/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #e78284 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #e78284 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #e78284 !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #e78284 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #e78284 24%, #414559) !important;
+      --button-background-color-primary: #e78284 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #e78284 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #e78284 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #e78284 !important;
+      --button-border-color-primary: #e78284 !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #e78284 !important;
+      --color-accent-primary-hover: rgb(235, 153, 154) !important;
+      --color-accent-primary-active: rgb(231, 154, 131) !important;
+      --focus-outline-color: #e78284 !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #e78284 !important;
+      --link-color-active: rgb(231, 154, 131) !important;
       --link-color-hover: rgb(235, 153, 154) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #e78284 !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #e78284 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #e78284 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #e78284 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #e78284 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #e78284 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #e78284 !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #e78284 22%, #414559) !important;
+      --in-content-primary-button-background: #e78284 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #e78284 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #e78284 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #e78284 !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #e78284 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #e78284 !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #e78284 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #e78284 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #e78284 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #e78284 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #e78284 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #e78284 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #e78284 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #e78284 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Rosewater/userChrome.css
+++ b/themes/Frappe/Rosewater/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Rosewater/userChrome.css
+++ b/themes/Frappe/Rosewater/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #f2d5cf !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Rosewater/userChrome.css
+++ b/themes/Frappe/Rosewater/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Rosewater/userChrome.css
+++ b/themes/Frappe/Rosewater/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Rosewater/userContent.css
+++ b/themes/Frappe/Rosewater/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f2d5cf 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f2d5cf 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #f2d5cf !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f2d5cf 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #f2d5cf 24%, #414559) !important;
+      --button-background-color-primary: #f2d5cf !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f2d5cf 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f2d5cf 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #f2d5cf !important;
+      --button-border-color-primary: #f2d5cf !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #f2d5cf !important;
+      --color-accent-primary-hover: rgb(248, 232, 228) !important;
+      --color-accent-primary-active: rgb(242, 222, 208) !important;
+      --focus-outline-color: #f2d5cf !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #f2d5cf !important;
+      --link-color-active: rgb(242, 222, 208) !important;
       --link-color-hover: rgb(248, 232, 228) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #f2d5cf !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f2d5cf 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #f2d5cf !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f2d5cf 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f2d5cf 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #f2d5cf !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #f2d5cf !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #f2d5cf 22%, #414559) !important;
+      --in-content-primary-button-background: #f2d5cf !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f2d5cf 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f2d5cf 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #f2d5cf !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f2d5cf !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #f2d5cf !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #f2d5cf !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f2d5cf 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f2d5cf 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #f2d5cf !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #f2d5cf !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #f2d5cf !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f2d5cf 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f2d5cf !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Rosewater/userContent.css
+++ b/themes/Frappe/Rosewater/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f2d5cf !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Sapphire/userChrome.css
+++ b/themes/Frappe/Sapphire/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Sapphire/userChrome.css
+++ b/themes/Frappe/Sapphire/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #85c1dc !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Sapphire/userChrome.css
+++ b/themes/Frappe/Sapphire/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Sapphire/userChrome.css
+++ b/themes/Frappe/Sapphire/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Sapphire/userContent.css
+++ b/themes/Frappe/Sapphire/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #85c1dc 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #85c1dc 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #85c1dc !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #85c1dc 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #85c1dc 24%, #414559) !important;
+      --button-background-color-primary: #85c1dc !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #85c1dc 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #85c1dc 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #85c1dc !important;
+      --button-border-color-primary: #85c1dc !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #85c1dc !important;
+      --color-accent-primary-hover: rgb(154, 203, 226) !important;
+      --color-accent-primary-active: rgb(134, 171, 220) !important;
+      --focus-outline-color: #85c1dc !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #85c1dc !important;
+      --link-color-active: rgb(134, 171, 220) !important;
       --link-color-hover: rgb(154, 203, 226) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #85c1dc !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #85c1dc 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #85c1dc !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #85c1dc 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #85c1dc 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #85c1dc !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #85c1dc !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #85c1dc 22%, #414559) !important;
+      --in-content-primary-button-background: #85c1dc !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #85c1dc 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #85c1dc 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #85c1dc !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #85c1dc !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #85c1dc !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #85c1dc !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #85c1dc 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #85c1dc 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #85c1dc !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #85c1dc !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #85c1dc !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #85c1dc 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #85c1dc !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Sapphire/userContent.css
+++ b/themes/Frappe/Sapphire/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #85c1dc !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Sky/userChrome.css
+++ b/themes/Frappe/Sky/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Sky/userChrome.css
+++ b/themes/Frappe/Sky/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #99d1db !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Sky/userChrome.css
+++ b/themes/Frappe/Sky/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Sky/userChrome.css
+++ b/themes/Frappe/Sky/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Sky/userContent.css
+++ b/themes/Frappe/Sky/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #99d1db !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Sky/userContent.css
+++ b/themes/Frappe/Sky/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #99d1db 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #99d1db 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #99d1db !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #99d1db 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #99d1db 24%, #414559) !important;
+      --button-background-color-primary: #99d1db !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #99d1db 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #99d1db 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #99d1db !important;
+      --button-border-color-primary: #99d1db !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #99d1db !important;
+      --color-accent-primary-hover: rgb(172, 218, 226) !important;
+      --color-accent-primary-active: rgb(153, 193, 219) !important;
+      --focus-outline-color: #99d1db !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #99d1db !important;
+      --link-color-active: rgb(153, 193, 219) !important;
       --link-color-hover: rgb(172, 218, 226) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #99d1db !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #99d1db 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #99d1db !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #99d1db 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #99d1db 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #99d1db !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #99d1db !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #99d1db 22%, #414559) !important;
+      --in-content-primary-button-background: #99d1db !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #99d1db 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #99d1db 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #99d1db !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #99d1db !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #99d1db !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #99d1db !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #99d1db 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #99d1db 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #99d1db !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #99d1db !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #99d1db !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #99d1db 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #99d1db !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Teal/userChrome.css
+++ b/themes/Frappe/Teal/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Teal/userChrome.css
+++ b/themes/Frappe/Teal/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Teal/userChrome.css
+++ b/themes/Frappe/Teal/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Teal/userChrome.css
+++ b/themes/Frappe/Teal/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #81c8be !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Teal/userContent.css
+++ b/themes/Frappe/Teal/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #81c8be !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Frappe/Teal/userContent.css
+++ b/themes/Frappe/Teal/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #81c8be 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #81c8be 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #81c8be !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #81c8be 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #81c8be 24%, #414559) !important;
+      --button-background-color-primary: #81c8be !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #81c8be 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #81c8be 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #81c8be !important;
+      --button-border-color-primary: #81c8be !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #81c8be !important;
+      --color-accent-primary-hover: rgb(148, 208, 200) !important;
+      --color-accent-primary-active: rgb(130, 192, 200) !important;
+      --focus-outline-color: #81c8be !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #81c8be !important;
+      --link-color-active: rgb(130, 192, 200) !important;
       --link-color-hover: rgb(148, 208, 200) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #81c8be !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #81c8be 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #81c8be !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #81c8be 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #81c8be 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #81c8be !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #81c8be !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #81c8be 22%, #414559) !important;
+      --in-content-primary-button-background: #81c8be !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #81c8be 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #81c8be 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #81c8be !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #81c8be !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #81c8be !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #81c8be !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #81c8be 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #81c8be 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #81c8be !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #81c8be !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #81c8be !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #81c8be 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #81c8be !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Yellow/userChrome.css
+++ b/themes/Frappe/Yellow/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #292c3c !important;
+    background-color: #292c3c !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #414559 !important;
+    background-color: #414559 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #292c3c !important;
+      --zen-main-browser-background-toolbar: #292c3c !important;
+      --zen-main-browser-background-old: #292c3c !important;
+      --zen-main-browser-background-toolbar-old: #292c3c !important;
+      --zen-navigator-toolbox-background: #292c3c !important;
+    }
+  }
 }

--- a/themes/Frappe/Yellow/userChrome.css
+++ b/themes/Frappe/Yellow/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #292c3c !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #303446 !important;
+    --catppuccin-quit-dialog-fg: #c6d0f5 !important;
+    --catppuccin-quit-dialog-accent: #e5c890 !important;
+    --catppuccin-quit-dialog-button-bg: #414559 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #51576d !important;
+    --catppuccin-quit-dialog-button-bg-active: #626880 !important;
+    --catppuccin-quit-dialog-button-border: #626880 !important;
+    --catppuccin-quit-dialog-muted: #a5adce !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #292c3c;
@@ -179,9 +189,118 @@
     background-color: #292c3c !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Frappe/Yellow/userChrome.css
+++ b/themes/Frappe/Yellow/userChrome.css
@@ -40,6 +40,50 @@
     color: #292c3c !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    --lwt-sidebar-background-color: #303446 !important;
+    --lwt-sidebar-text-color: #c6d0f5 !important;
+    background: #303446 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #303446 !important;
+    --lwt-toolbar-field-focus: #303446 !important;
+    --lwt-toolbar-field-border-color: #303446 !important;
+    border-color: #303446 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #303446 !important;
+    --sidebar-text-color: #c6d0f5 !important;
+    --sidebar-border-color: #303446 !important;
+    background: #303446 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #303446 !important;
   }

--- a/themes/Frappe/Yellow/userChrome.css
+++ b/themes/Frappe/Yellow/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #292c3c !important;
     --zen-main-browser-background: #292c3c !important;
     --toolbox-bgcolor-inactive: #292c3c !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #ca9ee6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #292c3c !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #292c3c !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #292c3c;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #292c3c 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Frappe base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #292c3c !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #292c3c !important;
-    background-color: #292c3c !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #414559 !important;
-    background-color: #414559 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #292c3c !important;
-      --zen-main-browser-background-toolbar: #292c3c !important;
-      --zen-main-browser-background-old: #292c3c !important;
-      --zen-main-browser-background-toolbar-old: #292c3c !important;
-      --zen-navigator-toolbox-background: #292c3c !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Frappe/Yellow/userContent.css
+++ b/themes/Frappe/Yellow/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #292c3c !important;
-      --in-content-text-color: #c6d0f5 !important;
+      --background-color-canvas: #232634 !important;
+      --background-color-box: #303446 !important;
+      --background-color-box-info: #414559 !important;
+      --background-color-critical: color-mix(in srgb, #e78284 18%, #303446) !important;
+      --background-color-information: color-mix(in srgb, #8caaee 18%, #303446) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #e5c890 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #e5c890 26%, #414559) !important;
+      --background-color-success: color-mix(in srgb, #a6d189 18%, #303446) !important;
+      --background-color-warning: color-mix(in srgb, #e5c890 18%, #303446) !important;
+      --border-color: #51576d !important;
+      --border-color-deemphasized: #414559 !important;
+      --border-color-interactive: #626880 !important;
+      --border-color-interactive-hover: #737994 !important;
+      --border-color-interactive-active: #838ba7 !important;
+      --border-color-selected: #e5c890 !important;
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #e5c890 24%, #414559) !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+      --button-background-color: #414559 !important;
+      --button-background-color-hover: #51576d !important;
+      --button-background-color-active: #626880 !important;
+      --button-background-color-selected: color-mix(in srgb, #e5c890 24%, #414559) !important;
+      --button-background-color-primary: #e5c890 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #e5c890 86%, #c6d0f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #e5c890 94%, #303446) !important;
+      --button-border-color: #51576d !important;
+      --button-border-color-hover: #626880 !important;
+      --button-border-color-active: #e5c890 !important;
+      --button-border-color-primary: #e5c890 !important;
+      --button-text-color: #c6d0f5 !important;
+      --button-text-color-hover: #c6d0f5 !important;
+      --button-text-color-active: #c6d0f5 !important;
+      --button-text-color-primary: #232634 !important;
+      --button-text-color-primary-hover: #232634 !important;
+      --button-text-color-primary-active: #232634 !important;
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+      --color-accent-primary: #e5c890 !important;
+      --color-accent-primary-hover: rgb(234, 211, 166) !important;
+      --color-accent-primary-active: rgb(229, 222, 145) !important;
+      --focus-outline-color: #e5c890 !important;
+      --icon-color: #b5bfe2 !important;
+      --icon-color-critical: #e78284 !important;
+      --icon-color-information: #8caaee !important;
+      --icon-color-success: #a6d189 !important;
+      --icon-color-warning: #e5c890 !important;
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
       --link-color: #e5c890 !important;
+      --link-color-active: rgb(229, 222, 145) !important;
       --link-color-hover: rgb(234, 211, 166) !important;
-      --zen-colors-primary: #414559 !important;
+      --link-color-visited: #ca9ee6 !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #e5c890 !important;
+      --select-text-color: #c6d0f5 !important;
+      --table-row-background-color-alternate: #292c3c !important;
+      --table-row-background-color-hover: #414559 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #e5c890 24%, #414559) !important;
+      --text-color: #c6d0f5 !important;
+      --text-color-deemphasized: #b5bfe2 !important;
+      --text-color-disabled: #737994 !important;
+      --text-color-error: #e78284 !important;
+      --text-color-success: #a6d189 !important;
+      --text-color-warning: #e5c890 !important;
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #e5c890 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #e5c890 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #e5c890 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #e5c890 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+      --zen-colors-tertiary: #292c3c !important;
+      --zen-colors-border: #51576d !important;
+      --zen-colors-hover-bg: #414559 !important;
+      --in-content-text-color: #c6d0f5 !important;
+      --in-content-page-background: #232634 !important;
+      --in-content-page-color: #c6d0f5 !important;
       --in-content-box-background: #414559 !important;
+      --in-content-box-background-odd: #292c3c !important;
+      --in-content-box-border-color: #51576d !important;
+      --in-content-border-color: #51576d !important;
+      --in-content-button-background: #414559 !important;
+      --in-content-button-background-hover: #51576d !important;
+      --in-content-button-background-active: #626880 !important;
+      --in-content-button-border-color: #51576d !important;
+      --in-content-button-border-color-hover: #626880 !important;
+      --in-content-button-border-color-active: #e5c890 !important;
+      --in-content-button-text-color: #c6d0f5 !important;
+      --in-content-deemphasized-text: #b5bfe2 !important;
+      --in-content-item-hover: #414559 !important;
+      --in-content-item-selected: color-mix(in srgb, #e5c890 22%, #414559) !important;
+      --in-content-primary-button-background: #e5c890 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #e5c890 86%, #c6d0f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #e5c890 94%, #303446) !important;
+      --in-content-primary-button-text-color: #232634 !important;
+      --zen-colors-primary: #414559 !important;
       --zen-primary-color: #e5c890 !important;
     }
 
-    groupbox , moz-card{
-      background: #303446 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #414559 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #232634 !important;
       color: #c6d0f5 !important;
     }
 
-    .main-content {
-      background-color: #232634 !important;
+    .navigation {
+      background: #292c3c !important;
+      color: #c6d0f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #414559 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #e5c890 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #303446 !important;
+      border: 1px solid #51576d !important;
+      box-shadow: none !important;
+      color: #c6d0f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #303446 !important;
+      --card-border-color: #51576d !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #626880 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #303446 !important;
+      --box-border-color: #51576d !important;
+      --box-button-background-color: #414559 !important;
+      --box-button-background-color-hover: #51576d !important;
+      --box-button-background-color-active: #626880 !important;
+      --box-button-text-color: #c6d0f5 !important;
+      --box-icon-color: #b5bfe2 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #292c3c !important;
+      --input-text-border-color: #626880 !important;
+      --input-text-color: #c6d0f5 !important;
+      --input-text-placeholder-color: #a5adce !important;
+      --select-background-color: #414559 !important;
+      --select-background-color-hover: #51576d !important;
+      --select-background-color-active: #626880 !important;
+      --select-border-color: #51576d !important;
+      --select-border-color-hover: #626880 !important;
+      --select-border-color-active: #e5c890 !important;
+      --select-text-color: #c6d0f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #51576d !important;
+      --toggle-background-color-hover: #626880 !important;
+      --toggle-background-color-pressed: #e5c890 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #e5c890 86%, #c6d0f5) !important;
+      --toggle-dot-background-color: #c6d0f5 !important;
+      --toggle-dot-background-color-on-pressed: #232634 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #303446 !important;
+      --visual-picker-item-background-color-hover: #414559 !important;
+      --visual-picker-item-background-color-active: #51576d !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #e5c890 16%, #414559) !important;
+      --visual-picker-item-border-color: #51576d !important;
+      --visual-picker-item-border-color-hover: #626880 !important;
+      --visual-picker-item-border-color-selected: #e5c890 !important;
+      --visual-picker-item-check-icon-color: #232634 !important;
+      --visual-picker-item-icon-color: #b5bfe2 !important;
+      --visual-picker-item-text-color: #c6d0f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #414559 !important;
+      color: #c6d0f5 !important;
+      border-color: #51576d !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #626880 !important;
+      border-color: #e5c890 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #414559 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #51576d !important;
+      border-color: #626880 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #292c3c !important;
+      border-color: #e5c890 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #e5c890 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #414559 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #303446 !important;
+      border-color: #51576d !important;
+      color: #c6d0f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #414559 !important;
+      border-color: #626880 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #414559 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #e5c890 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #8caaee !important;
+      --identity-icon-color: #8caaee !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #81c8be !important;
+      --identity-icon-color: #81c8be !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6d189 !important;
+      --identity-icon-color: #a6d189 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #e5c890 !important;
+      --identity-icon-color: #e5c890 !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #ef9f76 !important;
+      --identity-icon-color: #ef9f76 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #e78284 !important;
+      --identity-icon-color: #e78284 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f4b8e4 !important;
+      --identity-icon-color: #f4b8e4 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #ca9ee6 !important;
+      --identity-icon-color: #ca9ee6 !important;
     }
   }
 

--- a/themes/Frappe/Yellow/userContent.css
+++ b/themes/Frappe/Yellow/userContent.css
@@ -202,6 +202,12 @@
       color: #c6d0f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #414559 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #e5c890 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Blue/userChrome.css
+++ b/themes/Latte/Blue/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Blue/userChrome.css
+++ b/themes/Latte/Blue/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Blue/userChrome.css
+++ b/themes/Latte/Blue/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Blue/userChrome.css
+++ b/themes/Latte/Blue/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #1e66f5 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Blue/userContent.css
+++ b/themes/Latte/Blue/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #1e66f5 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Blue/userContent.css
+++ b/themes/Latte/Blue/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #1e66f5 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #1e66f5 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #1e66f5 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #1e66f5 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #1e66f5 24%, #ccd0da) !important;
+      --button-background-color-primary: #1e66f5 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #1e66f5 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #1e66f5 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #1e66f5 !important;
+      --button-border-color-primary: #1e66f5 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #1e66f5 !important;
+      --color-accent-primary-hover: rgb(56, 119, 246) !important;
+      --color-accent-primary-active: rgb(31, 49, 245) !important;
+      --focus-outline-color: #1e66f5 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #1e66f5 !important;
+      --link-color-active: rgb(31, 49, 245) !important;
       --link-color-hover: rgb(56, 119, 246) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #1e66f5 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #1e66f5 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #1e66f5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #1e66f5 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #1e66f5 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #1e66f5 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #1e66f5 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #1e66f5 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #1e66f5 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #1e66f5 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #1e66f5 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #1e66f5 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #1e66f5 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #1e66f5 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #1e66f5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #1e66f5 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #1e66f5 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #1e66f5 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #1e66f5 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #1e66f5 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #1e66f5 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #1e66f5 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Flamingo/userChrome.css
+++ b/themes/Latte/Flamingo/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Flamingo/userChrome.css
+++ b/themes/Latte/Flamingo/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Flamingo/userChrome.css
+++ b/themes/Latte/Flamingo/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Flamingo/userChrome.css
+++ b/themes/Latte/Flamingo/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #dd7878 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Flamingo/userContent.css
+++ b/themes/Latte/Flamingo/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #dd7878 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #dd7878 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #dd7878 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #dd7878 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #dd7878 24%, #ccd0da) !important;
+      --button-background-color-primary: #dd7878 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #dd7878 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #dd7878 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #dd7878 !important;
+      --button-border-color-primary: #dd7878 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #dd7878 !important;
+      --color-accent-primary-hover: rgb(226, 142, 142) !important;
+      --color-accent-primary-active: rgb(221, 146, 121) !important;
+      --focus-outline-color: #dd7878 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #dd7878 !important;
+      --link-color-active: rgb(221, 146, 121) !important;
       --link-color-hover: rgb(226, 142, 142) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #dd7878 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #dd7878 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #dd7878 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #dd7878 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #dd7878 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #dd7878 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #dd7878 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #dd7878 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #dd7878 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #dd7878 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #dd7878 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #dd7878 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #dd7878 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #dd7878 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #dd7878 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #dd7878 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #dd7878 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #dd7878 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #dd7878 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #dd7878 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #dd7878 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #dd7878 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Flamingo/userContent.css
+++ b/themes/Latte/Flamingo/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #dd7878 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Green/userChrome.css
+++ b/themes/Latte/Green/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Green/userChrome.css
+++ b/themes/Latte/Green/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #40a02b !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Green/userChrome.css
+++ b/themes/Latte/Green/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Green/userChrome.css
+++ b/themes/Latte/Green/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Green/userContent.css
+++ b/themes/Latte/Green/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #40a02b 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #40a02b 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #40a02b !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #40a02b 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #40a02b 24%, #ccd0da) !important;
+      --button-background-color-primary: #40a02b !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #40a02b 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #40a02b 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #40a02b !important;
+      --button-border-color-primary: #40a02b !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #40a02b !important;
+      --color-accent-primary-hover: rgb(73, 181, 49) !important;
+      --color-accent-primary-active: rgb(43, 161, 51) !important;
+      --focus-outline-color: #40a02b !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #40a02b !important;
+      --link-color-active: rgb(43, 161, 51) !important;
       --link-color-hover: rgb(73, 181, 49) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #40a02b !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #40a02b 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #40a02b !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #40a02b 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #40a02b 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #40a02b !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #40a02b !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #40a02b 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #40a02b !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #40a02b 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #40a02b 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #40a02b !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #40a02b !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #40a02b !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #40a02b !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #40a02b 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #40a02b 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #40a02b !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #40a02b !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #40a02b !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #40a02b 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #40a02b !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Green/userContent.css
+++ b/themes/Latte/Green/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #40a02b !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Lavender/userChrome.css
+++ b/themes/Latte/Lavender/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Lavender/userChrome.css
+++ b/themes/Latte/Lavender/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #7287fd !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Lavender/userChrome.css
+++ b/themes/Latte/Lavender/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Lavender/userChrome.css
+++ b/themes/Latte/Lavender/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Lavender/userContent.css
+++ b/themes/Latte/Lavender/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #7287fd !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Lavender/userContent.css
+++ b/themes/Latte/Lavender/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #7287fd 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #7287fd 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #7287fd !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #7287fd 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #7287fd 24%, #ccd0da) !important;
+      --button-background-color-primary: #7287fd !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #7287fd 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #7287fd 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #7287fd !important;
+      --button-border-color-primary: #7287fd !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #7287fd !important;
+      --color-accent-primary-hover: rgb(141, 158, 253) !important;
+      --color-accent-primary-active: rgb(129, 115, 253) !important;
+      --focus-outline-color: #7287fd !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #7287fd !important;
+      --link-color-active: rgb(129, 115, 253) !important;
       --link-color-hover: rgb(141, 158, 253) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #7287fd !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #7287fd 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #7287fd !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #7287fd 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #7287fd 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #7287fd !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #7287fd !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #7287fd 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #7287fd !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #7287fd 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #7287fd 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #7287fd !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #7287fd !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #7287fd !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #7287fd !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #7287fd 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #7287fd 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #7287fd !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #7287fd !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #7287fd !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #7287fd 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #7287fd !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Maroon/userChrome.css
+++ b/themes/Latte/Maroon/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Maroon/userChrome.css
+++ b/themes/Latte/Maroon/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #e64553 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Maroon/userChrome.css
+++ b/themes/Latte/Maroon/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Maroon/userChrome.css
+++ b/themes/Latte/Maroon/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Maroon/userContent.css
+++ b/themes/Latte/Maroon/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #e64553 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #e64553 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #e64553 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #e64553 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #e64553 24%, #ccd0da) !important;
+      --button-background-color-primary: #e64553 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #e64553 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #e64553 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #e64553 !important;
+      --button-border-color-primary: #e64553 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #e64553 !important;
+      --color-accent-primary-hover: rgb(233, 93, 104) !important;
+      --color-accent-primary-active: rgb(230, 96, 70) !important;
+      --focus-outline-color: #e64553 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #e64553 !important;
+      --link-color-active: rgb(230, 96, 70) !important;
       --link-color-hover: rgb(233, 93, 104) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #e64553 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #e64553 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #e64553 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #e64553 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #e64553 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #e64553 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #e64553 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #e64553 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #e64553 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #e64553 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #e64553 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #e64553 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #e64553 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #e64553 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #e64553 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #e64553 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #e64553 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #e64553 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #e64553 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #e64553 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #e64553 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #e64553 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Maroon/userContent.css
+++ b/themes/Latte/Maroon/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #e64553 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Mauve/userChrome.css
+++ b/themes/Latte/Mauve/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Mauve/userChrome.css
+++ b/themes/Latte/Mauve/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Mauve/userChrome.css
+++ b/themes/Latte/Mauve/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Mauve/userChrome.css
+++ b/themes/Latte/Mauve/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #8839ef !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Mauve/userContent.css
+++ b/themes/Latte/Mauve/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #8839ef 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #8839ef 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #8839ef !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #8839ef 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #8839ef 24%, #ccd0da) !important;
+      --button-background-color-primary: #8839ef !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #8839ef 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #8839ef 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #8839ef !important;
+      --button-border-color-primary: #8839ef !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #8839ef !important;
+      --color-accent-primary-hover: rgb(150, 81, 241) !important;
+      --color-accent-primary-active: rgb(181, 57, 239) !important;
+      --focus-outline-color: #8839ef !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #8839ef !important;
+      --link-color-active: rgb(181, 57, 239) !important;
       --link-color-hover: rgb(150, 81, 241) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #8839ef !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #8839ef 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #8839ef !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8839ef 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8839ef 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #8839ef !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #8839ef !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #8839ef 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #8839ef !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #8839ef 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #8839ef 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #8839ef !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #8839ef !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #8839ef !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #8839ef !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8839ef 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8839ef 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #8839ef !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #8839ef !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #8839ef !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #8839ef 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #8839ef !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Mauve/userContent.css
+++ b/themes/Latte/Mauve/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #8839ef !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Peach/userChrome.css
+++ b/themes/Latte/Peach/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Peach/userChrome.css
+++ b/themes/Latte/Peach/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #fe640b !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Peach/userChrome.css
+++ b/themes/Latte/Peach/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Peach/userChrome.css
+++ b/themes/Latte/Peach/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Peach/userContent.css
+++ b/themes/Latte/Peach/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #fe640b !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Peach/userContent.css
+++ b/themes/Latte/Peach/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #fe640b 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #fe640b 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #fe640b !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #fe640b 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #fe640b 24%, #ccd0da) !important;
+      --button-background-color-primary: #fe640b !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #fe640b 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #fe640b 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #fe640b !important;
+      --button-border-color-primary: #fe640b !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #fe640b !important;
+      --color-accent-primary-hover: rgb(254, 117, 38) !important;
+      --color-accent-primary-active: rgb(254, 161, 12) !important;
+      --focus-outline-color: #fe640b !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #fe640b !important;
+      --link-color-active: rgb(254, 161, 12) !important;
       --link-color-hover: rgb(254, 117, 38) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #fe640b !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #fe640b 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #fe640b !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #fe640b 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #fe640b 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #fe640b !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #fe640b !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #fe640b 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #fe640b !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #fe640b 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #fe640b 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #fe640b !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #fe640b !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #fe640b !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #fe640b !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #fe640b 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #fe640b 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #fe640b !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #fe640b !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #fe640b !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #fe640b 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #fe640b !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Pink/userChrome.css
+++ b/themes/Latte/Pink/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Pink/userChrome.css
+++ b/themes/Latte/Pink/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #ea76cb !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Pink/userChrome.css
+++ b/themes/Latte/Pink/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Pink/userChrome.css
+++ b/themes/Latte/Pink/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Pink/userContent.css
+++ b/themes/Latte/Pink/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #ea76cb 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #ea76cb 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #ea76cb !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #ea76cb 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #ea76cb 24%, #ccd0da) !important;
+      --button-background-color-primary: #ea76cb !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #ea76cb 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #ea76cb 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #ea76cb !important;
+      --button-border-color-primary: #ea76cb !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #ea76cb !important;
+      --color-accent-primary-hover: rgb(237, 141, 212) !important;
+      --color-accent-primary-active: rgb(234, 118, 174) !important;
+      --focus-outline-color: #ea76cb !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #ea76cb !important;
+      --link-color-active: rgb(234, 118, 174) !important;
       --link-color-hover: rgb(237, 141, 212) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #ea76cb !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #ea76cb 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #ea76cb !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ea76cb 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ea76cb 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #ea76cb !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #ea76cb !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #ea76cb 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #ea76cb !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #ea76cb 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #ea76cb 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #ea76cb !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #ea76cb !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #ea76cb !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #ea76cb !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ea76cb 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ea76cb 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #ea76cb !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #ea76cb !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #ea76cb !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #ea76cb 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #ea76cb !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Pink/userContent.css
+++ b/themes/Latte/Pink/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #ea76cb !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Red/userChrome.css
+++ b/themes/Latte/Red/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #d20f39 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Red/userChrome.css
+++ b/themes/Latte/Red/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Red/userChrome.css
+++ b/themes/Latte/Red/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Red/userChrome.css
+++ b/themes/Latte/Red/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Red/userContent.css
+++ b/themes/Latte/Red/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #d20f39 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #d20f39 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #d20f39 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #d20f39 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #d20f39 24%, #ccd0da) !important;
+      --button-background-color-primary: #d20f39 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #d20f39 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #d20f39 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #d20f39 !important;
+      --button-border-color-primary: #d20f39 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #d20f39 !important;
+      --color-accent-primary-hover: rgb(235, 17, 64) !important;
+      --color-accent-primary-active: rgb(211, 22, 15) !important;
+      --focus-outline-color: #d20f39 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #d20f39 !important;
+      --link-color-active: rgb(211, 22, 15) !important;
       --link-color-hover: rgb(235, 17, 64) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #d20f39 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #d20f39 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #d20f39 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #d20f39 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #d20f39 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #d20f39 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #d20f39 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #d20f39 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #d20f39 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #d20f39 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #d20f39 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #d20f39 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #d20f39 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #d20f39 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #d20f39 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #d20f39 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #d20f39 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #d20f39 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #d20f39 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #d20f39 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #d20f39 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #d20f39 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Red/userContent.css
+++ b/themes/Latte/Red/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #d20f39 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Rosewater/userChrome.css
+++ b/themes/Latte/Rosewater/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Rosewater/userChrome.css
+++ b/themes/Latte/Rosewater/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Rosewater/userChrome.css
+++ b/themes/Latte/Rosewater/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Rosewater/userChrome.css
+++ b/themes/Latte/Rosewater/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #dc8a78 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Rosewater/userContent.css
+++ b/themes/Latte/Rosewater/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #dc8a78 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #dc8a78 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #dc8a78 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #dc8a78 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #dc8a78 24%, #ccd0da) !important;
+      --button-background-color-primary: #dc8a78 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #dc8a78 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #dc8a78 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #dc8a78 !important;
+      --button-border-color-primary: #dc8a78 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #dc8a78 !important;
+      --color-accent-primary-hover: rgb(225, 156, 141) !important;
+      --color-accent-primary-active: rgb(220, 163, 120) !important;
+      --focus-outline-color: #dc8a78 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #dc8a78 !important;
+      --link-color-active: rgb(220, 163, 120) !important;
       --link-color-hover: rgb(225, 156, 141) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #dc8a78 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #dc8a78 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #dc8a78 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #dc8a78 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #dc8a78 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #dc8a78 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #dc8a78 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #dc8a78 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #dc8a78 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #dc8a78 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #dc8a78 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #dc8a78 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #dc8a78 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #dc8a78 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #dc8a78 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #dc8a78 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #dc8a78 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #dc8a78 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #dc8a78 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #dc8a78 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #dc8a78 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #dc8a78 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Rosewater/userContent.css
+++ b/themes/Latte/Rosewater/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #dc8a78 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Sapphire/userChrome.css
+++ b/themes/Latte/Sapphire/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Sapphire/userChrome.css
+++ b/themes/Latte/Sapphire/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #209fb5 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Sapphire/userChrome.css
+++ b/themes/Latte/Sapphire/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Sapphire/userChrome.css
+++ b/themes/Latte/Sapphire/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Sapphire/userContent.css
+++ b/themes/Latte/Sapphire/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #209fb5 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Sapphire/userContent.css
+++ b/themes/Latte/Sapphire/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #209fb5 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #209fb5 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #209fb5 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #209fb5 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #209fb5 24%, #ccd0da) !important;
+      --button-background-color-primary: #209fb5 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #209fb5 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #209fb5 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #209fb5 !important;
+      --button-border-color-primary: #209fb5 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #209fb5 !important;
+      --color-accent-primary-hover: rgb(36, 179, 204) !important;
+      --color-accent-primary-active: rgb(32, 122, 182) !important;
+      --focus-outline-color: #209fb5 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #209fb5 !important;
+      --link-color-active: rgb(32, 122, 182) !important;
       --link-color-hover: rgb(36, 179, 204) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #209fb5 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #209fb5 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #209fb5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #209fb5 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #209fb5 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #209fb5 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #209fb5 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #209fb5 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #209fb5 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #209fb5 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #209fb5 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #209fb5 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #209fb5 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #209fb5 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #209fb5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #209fb5 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #209fb5 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #209fb5 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #209fb5 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #209fb5 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #209fb5 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #209fb5 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Sky/userChrome.css
+++ b/themes/Latte/Sky/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Sky/userChrome.css
+++ b/themes/Latte/Sky/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #04a5e5 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Sky/userChrome.css
+++ b/themes/Latte/Sky/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Sky/userChrome.css
+++ b/themes/Latte/Sky/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Sky/userContent.css
+++ b/themes/Latte/Sky/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #04a5e5 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Sky/userContent.css
+++ b/themes/Latte/Sky/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #04a5e5 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #04a5e5 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #04a5e5 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #04a5e5 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #04a5e5 24%, #ccd0da) !important;
+      --button-background-color-primary: #04a5e5 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #04a5e5 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #04a5e5 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #04a5e5 !important;
+      --button-border-color-primary: #04a5e5 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #04a5e5 !important;
+      --color-accent-primary-hover: rgb(9, 182, 251) !important;
+      --color-accent-primary-active: rgb(4, 109, 230) !important;
+      --focus-outline-color: #04a5e5 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #04a5e5 !important;
+      --link-color-active: rgb(4, 109, 230) !important;
       --link-color-hover: rgb(9, 182, 251) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #04a5e5 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #04a5e5 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #04a5e5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #04a5e5 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #04a5e5 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #04a5e5 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #04a5e5 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #04a5e5 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #04a5e5 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #04a5e5 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #04a5e5 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #04a5e5 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #04a5e5 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #04a5e5 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #04a5e5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #04a5e5 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #04a5e5 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #04a5e5 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #04a5e5 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #04a5e5 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #04a5e5 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #04a5e5 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Teal/userChrome.css
+++ b/themes/Latte/Teal/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Teal/userChrome.css
+++ b/themes/Latte/Teal/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Teal/userChrome.css
+++ b/themes/Latte/Teal/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Teal/userChrome.css
+++ b/themes/Latte/Teal/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #179299 !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Teal/userContent.css
+++ b/themes/Latte/Teal/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #179299 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Latte/Teal/userContent.css
+++ b/themes/Latte/Teal/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #179299 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #179299 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #179299 !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #179299 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #179299 24%, #ccd0da) !important;
+      --button-background-color-primary: #179299 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #179299 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #179299 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #179299 !important;
+      --button-border-color-primary: #179299 !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #179299 !important;
+      --color-accent-primary-hover: rgb(27, 168, 175) !important;
+      --color-accent-primary-active: rgb(23, 114, 153) !important;
+      --focus-outline-color: #179299 !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #179299 !important;
+      --link-color-active: rgb(23, 114, 153) !important;
       --link-color-hover: rgb(27, 168, 175) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #179299 !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #179299 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #179299 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #179299 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #179299 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #179299 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #179299 !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #179299 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #179299 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #179299 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #179299 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #179299 !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #179299 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #179299 !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #179299 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #179299 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #179299 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #179299 !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #179299 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #179299 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #179299 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #179299 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Yellow/userChrome.css
+++ b/themes/Latte/Yellow/userChrome.css
@@ -40,6 +40,50 @@
     color: #e6e9ef !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    --lwt-sidebar-background-color: #eff1f5 !important;
+    --lwt-sidebar-text-color: #4c4f69 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #eff1f5 !important;
+    --lwt-toolbar-field-focus: #eff1f5 !important;
+    --lwt-toolbar-field-border-color: #eff1f5 !important;
+    border-color: #eff1f5 !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #eff1f5 !important;
+    --sidebar-text-color: #4c4f69 !important;
+    --sidebar-border-color: #eff1f5 !important;
+    background: #eff1f5 !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #eff1f5 !important;
   }

--- a/themes/Latte/Yellow/userChrome.css
+++ b/themes/Latte/Yellow/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #e6e9ef !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #eff1f5 !important;
+    --catppuccin-quit-dialog-fg: #4c4f69 !important;
+    --catppuccin-quit-dialog-accent: #df8e1d !important;
+    --catppuccin-quit-dialog-button-bg: #ccd0da !important;
+    --catppuccin-quit-dialog-button-bg-hover: #bcc0cc !important;
+    --catppuccin-quit-dialog-button-bg-active: #acb0be !important;
+    --catppuccin-quit-dialog-button-border: #acb0be !important;
+    --catppuccin-quit-dialog-muted: #6c6f85 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #e6e9ef;
@@ -179,9 +189,118 @@
     background-color: #e6e9ef !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: light !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Latte/Yellow/userChrome.css
+++ b/themes/Latte/Yellow/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #e6e9ef !important;
+    background-color: #e6e9ef !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #ccd0da !important;
+    background-color: #ccd0da !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
+      --zen-main-browser-background-toolbar: #e6e9ef !important;
+      --zen-main-browser-background-old: #e6e9ef !important;
+      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
+      --zen-navigator-toolbox-background: #e6e9ef !important;
+    }
+  }
 }

--- a/themes/Latte/Yellow/userChrome.css
+++ b/themes/Latte/Yellow/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #e6e9ef !important;
     --zen-main-browser-background: #e6e9ef !important;
     --toolbox-bgcolor-inactive: #e6e9ef !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #8839ef !important;
   }
 
-  hbox#titlebar {
-    background-color: #e6e9ef !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #e6e9ef !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #e6e9ef;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #e6e9ef 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Latte base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #e6e9ef !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #e6e9ef !important;
-    background-color: #e6e9ef !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #ccd0da !important;
-    background-color: #ccd0da !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #e6e9ef !important;
-      --zen-main-browser-background-toolbar: #e6e9ef !important;
-      --zen-main-browser-background-old: #e6e9ef !important;
-      --zen-main-browser-background-toolbar-old: #e6e9ef !important;
-      --zen-navigator-toolbox-background: #e6e9ef !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Latte/Yellow/userContent.css
+++ b/themes/Latte/Yellow/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #e6e9ef !important;
-      --in-content-text-color: #4c4f69 !important;
+      --background-color-canvas: #dce0e8 !important;
+      --background-color-box: #eff1f5 !important;
+      --background-color-box-info: #ccd0da !important;
+      --background-color-critical: color-mix(in srgb, #d20f39 18%, #eff1f5) !important;
+      --background-color-information: color-mix(in srgb, #1e66f5 18%, #eff1f5) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #df8e1d 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #df8e1d 26%, #ccd0da) !important;
+      --background-color-success: color-mix(in srgb, #40a02b 18%, #eff1f5) !important;
+      --background-color-warning: color-mix(in srgb, #df8e1d 18%, #eff1f5) !important;
+      --border-color: #bcc0cc !important;
+      --border-color-deemphasized: #ccd0da !important;
+      --border-color-interactive: #acb0be !important;
+      --border-color-interactive-hover: #9ca0b0 !important;
+      --border-color-interactive-active: #8c8fa1 !important;
+      --border-color-selected: #df8e1d !important;
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-background-color-selected: color-mix(in srgb, #df8e1d 24%, #ccd0da) !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+      --button-background-color: #ccd0da !important;
+      --button-background-color-hover: #bcc0cc !important;
+      --button-background-color-active: #acb0be !important;
+      --button-background-color-selected: color-mix(in srgb, #df8e1d 24%, #ccd0da) !important;
+      --button-background-color-primary: #df8e1d !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #df8e1d 86%, #4c4f69) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #df8e1d 94%, #eff1f5) !important;
+      --button-border-color: #bcc0cc !important;
+      --button-border-color-hover: #acb0be !important;
+      --button-border-color-active: #df8e1d !important;
+      --button-border-color-primary: #df8e1d !important;
+      --button-text-color: #4c4f69 !important;
+      --button-text-color-hover: #4c4f69 !important;
+      --button-text-color-active: #4c4f69 !important;
+      --button-text-color-primary: #dce0e8 !important;
+      --button-text-color-primary-hover: #dce0e8 !important;
+      --button-text-color-primary-active: #dce0e8 !important;
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+      --color-accent-primary: #df8e1d !important;
+      --color-accent-primary-hover: rgb(228, 154, 50) !important;
+      --color-accent-primary-active: rgb(223, 191, 29) !important;
+      --focus-outline-color: #df8e1d !important;
+      --icon-color: #5c5f77 !important;
+      --icon-color-critical: #d20f39 !important;
+      --icon-color-information: #1e66f5 !important;
+      --icon-color-success: #40a02b !important;
+      --icon-color-warning: #df8e1d !important;
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
       --link-color: #df8e1d !important;
+      --link-color-active: rgb(223, 191, 29) !important;
       --link-color-hover: rgb(228, 154, 50) !important;
-      --zen-colors-primary: #ccd0da !important;
+      --link-color-visited: #8839ef !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #df8e1d !important;
+      --select-text-color: #4c4f69 !important;
+      --table-row-background-color-alternate: #e6e9ef !important;
+      --table-row-background-color-hover: #ccd0da !important;
+      --table-row-background-color-selected: color-mix(in srgb, #df8e1d 24%, #ccd0da) !important;
+      --text-color: #4c4f69 !important;
+      --text-color-deemphasized: #5c5f77 !important;
+      --text-color-disabled: #9ca0b0 !important;
+      --text-color-error: #d20f39 !important;
+      --text-color-success: #40a02b !important;
+      --text-color-warning: #df8e1d !important;
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #df8e1d !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #df8e1d 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #df8e1d 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #df8e1d !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+      --zen-colors-tertiary: #e6e9ef !important;
+      --zen-colors-border: #bcc0cc !important;
+      --zen-colors-hover-bg: #ccd0da !important;
+      --in-content-text-color: #4c4f69 !important;
+      --in-content-page-background: #dce0e8 !important;
+      --in-content-page-color: #4c4f69 !important;
       --in-content-box-background: #ccd0da !important;
+      --in-content-box-background-odd: #e6e9ef !important;
+      --in-content-box-border-color: #bcc0cc !important;
+      --in-content-border-color: #bcc0cc !important;
+      --in-content-button-background: #ccd0da !important;
+      --in-content-button-background-hover: #bcc0cc !important;
+      --in-content-button-background-active: #acb0be !important;
+      --in-content-button-border-color: #bcc0cc !important;
+      --in-content-button-border-color-hover: #acb0be !important;
+      --in-content-button-border-color-active: #df8e1d !important;
+      --in-content-button-text-color: #4c4f69 !important;
+      --in-content-deemphasized-text: #5c5f77 !important;
+      --in-content-item-hover: #ccd0da !important;
+      --in-content-item-selected: color-mix(in srgb, #df8e1d 22%, #ccd0da) !important;
+      --in-content-primary-button-background: #df8e1d !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #df8e1d 86%, #4c4f69) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #df8e1d 94%, #eff1f5) !important;
+      --in-content-primary-button-text-color: #dce0e8 !important;
+      --zen-colors-primary: #ccd0da !important;
       --zen-primary-color: #df8e1d !important;
     }
 
-    groupbox , moz-card{
-      background: #eff1f5 !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #ccd0da !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #dce0e8 !important;
       color: #4c4f69 !important;
     }
 
-    .main-content {
-      background-color: #dce0e8 !important;
+    .navigation {
+      background: #e6e9ef !important;
+      color: #4c4f69 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #ccd0da !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #df8e1d !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #eff1f5 !important;
+      border: 1px solid #bcc0cc !important;
+      box-shadow: none !important;
+      color: #4c4f69 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #eff1f5 !important;
+      --card-border-color: #bcc0cc !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #acb0be !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #eff1f5 !important;
+      --box-border-color: #bcc0cc !important;
+      --box-button-background-color: #ccd0da !important;
+      --box-button-background-color-hover: #bcc0cc !important;
+      --box-button-background-color-active: #acb0be !important;
+      --box-button-text-color: #4c4f69 !important;
+      --box-icon-color: #5c5f77 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #e6e9ef !important;
+      --input-text-border-color: #acb0be !important;
+      --input-text-color: #4c4f69 !important;
+      --input-text-placeholder-color: #6c6f85 !important;
+      --select-background-color: #ccd0da !important;
+      --select-background-color-hover: #bcc0cc !important;
+      --select-background-color-active: #acb0be !important;
+      --select-border-color: #bcc0cc !important;
+      --select-border-color-hover: #acb0be !important;
+      --select-border-color-active: #df8e1d !important;
+      --select-text-color: #4c4f69 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #bcc0cc !important;
+      --toggle-background-color-hover: #acb0be !important;
+      --toggle-background-color-pressed: #df8e1d !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #df8e1d 86%, #4c4f69) !important;
+      --toggle-dot-background-color: #4c4f69 !important;
+      --toggle-dot-background-color-on-pressed: #dce0e8 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #eff1f5 !important;
+      --visual-picker-item-background-color-hover: #ccd0da !important;
+      --visual-picker-item-background-color-active: #bcc0cc !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #df8e1d 16%, #ccd0da) !important;
+      --visual-picker-item-border-color: #bcc0cc !important;
+      --visual-picker-item-border-color-hover: #acb0be !important;
+      --visual-picker-item-border-color-selected: #df8e1d !important;
+      --visual-picker-item-check-icon-color: #dce0e8 !important;
+      --visual-picker-item-icon-color: #5c5f77 !important;
+      --visual-picker-item-text-color: #4c4f69 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #ccd0da !important;
+      color: #4c4f69 !important;
+      border-color: #bcc0cc !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #acb0be !important;
+      border-color: #df8e1d !important;
+    }
+
+    .zenCKSOption-input {
+      background: #ccd0da !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #bcc0cc !important;
+      border-color: #acb0be !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #e6e9ef !important;
+      border-color: #df8e1d !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #df8e1d 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #ccd0da !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #eff1f5 !important;
+      border-color: #bcc0cc !important;
+      color: #4c4f69 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #ccd0da !important;
+      border-color: #acb0be !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #ccd0da !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #df8e1d !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #1e66f5 !important;
+      --identity-icon-color: #1e66f5 !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #179299 !important;
+      --identity-icon-color: #179299 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #40a02b !important;
+      --identity-icon-color: #40a02b !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #df8e1d !important;
+      --identity-icon-color: #df8e1d !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fe640b !important;
+      --identity-icon-color: #fe640b !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #d20f39 !important;
+      --identity-icon-color: #d20f39 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #ea76cb !important;
+      --identity-icon-color: #ea76cb !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #8839ef !important;
+      --identity-icon-color: #8839ef !important;
     }
   }
 

--- a/themes/Latte/Yellow/userContent.css
+++ b/themes/Latte/Yellow/userContent.css
@@ -202,6 +202,12 @@
       color: #4c4f69 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #ccd0da !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #df8e1d !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Blue/userChrome.css
+++ b/themes/Macchiato/Blue/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Blue/userChrome.css
+++ b/themes/Macchiato/Blue/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Blue/userChrome.css
+++ b/themes/Macchiato/Blue/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Blue/userChrome.css
+++ b/themes/Macchiato/Blue/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #8aadf4 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Blue/userContent.css
+++ b/themes/Macchiato/Blue/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #8aadf4 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #8aadf4 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #8aadf4 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #8aadf4 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #8aadf4 24%, #363a4f) !important;
+      --button-background-color-primary: #8aadf4 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #8aadf4 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #8aadf4 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #8aadf4 !important;
+      --button-border-color-primary: #8aadf4 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #8aadf4 !important;
+      --color-accent-primary-hover: rgb(162, 190, 246) !important;
+      --color-accent-primary-active: rgb(138, 147, 244) !important;
+      --focus-outline-color: #8aadf4 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #8aadf4 !important;
+      --link-color-active: rgb(138, 147, 244) !important;
       --link-color-hover: rgb(162, 190, 246) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #8aadf4 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #8aadf4 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #8aadf4 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8aadf4 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8aadf4 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #8aadf4 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #8aadf4 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #8aadf4 22%, #363a4f) !important;
+      --in-content-primary-button-background: #8aadf4 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #8aadf4 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #8aadf4 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #8aadf4 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #8aadf4 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #8aadf4 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #8aadf4 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8aadf4 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8aadf4 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #8aadf4 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #8aadf4 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #8aadf4 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #8aadf4 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #8aadf4 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Blue/userContent.css
+++ b/themes/Macchiato/Blue/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #8aadf4 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Flamingo/userChrome.css
+++ b/themes/Macchiato/Flamingo/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Flamingo/userChrome.css
+++ b/themes/Macchiato/Flamingo/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #f0c6c6 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Flamingo/userChrome.css
+++ b/themes/Macchiato/Flamingo/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Flamingo/userChrome.css
+++ b/themes/Macchiato/Flamingo/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Flamingo/userContent.css
+++ b/themes/Macchiato/Flamingo/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f0c6c6 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Flamingo/userContent.css
+++ b/themes/Macchiato/Flamingo/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f0c6c6 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f0c6c6 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #f0c6c6 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f0c6c6 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #f0c6c6 24%, #363a4f) !important;
+      --button-background-color-primary: #f0c6c6 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f0c6c6 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f0c6c6 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #f0c6c6 !important;
+      --button-border-color-primary: #f0c6c6 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #f0c6c6 !important;
+      --color-accent-primary-hover: rgb(245, 219, 219) !important;
+      --color-accent-primary-active: rgb(240, 208, 198) !important;
+      --focus-outline-color: #f0c6c6 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #f0c6c6 !important;
+      --link-color-active: rgb(240, 208, 198) !important;
       --link-color-hover: rgb(245, 219, 219) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f0c6c6 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f0c6c6 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f0c6c6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f0c6c6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f0c6c6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f0c6c6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #f0c6c6 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #f0c6c6 22%, #363a4f) !important;
+      --in-content-primary-button-background: #f0c6c6 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f0c6c6 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f0c6c6 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #f0c6c6 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f0c6c6 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f0c6c6 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f0c6c6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f0c6c6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f0c6c6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f0c6c6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #f0c6c6 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #f0c6c6 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f0c6c6 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f0c6c6 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Green/userChrome.css
+++ b/themes/Macchiato/Green/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Green/userChrome.css
+++ b/themes/Macchiato/Green/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #a6da95 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Green/userChrome.css
+++ b/themes/Macchiato/Green/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Green/userChrome.css
+++ b/themes/Macchiato/Green/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Green/userContent.css
+++ b/themes/Macchiato/Green/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #a6da95 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #a6da95 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #a6da95 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #a6da95 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #a6da95 24%, #363a4f) !important;
+      --button-background-color-primary: #a6da95 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #a6da95 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #a6da95 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #a6da95 !important;
+      --button-border-color-primary: #a6da95 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #a6da95 !important;
+      --color-accent-primary-hover: rgb(183, 225, 169) !important;
+      --color-accent-primary-active: rgb(150, 218, 150) !important;
+      --focus-outline-color: #a6da95 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #a6da95 !important;
+      --link-color-active: rgb(150, 218, 150) !important;
       --link-color-hover: rgb(183, 225, 169) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #a6da95 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #a6da95 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #a6da95 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #a6da95 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #a6da95 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #a6da95 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #a6da95 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #a6da95 22%, #363a4f) !important;
+      --in-content-primary-button-background: #a6da95 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #a6da95 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #a6da95 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #a6da95 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #a6da95 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #a6da95 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #a6da95 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #a6da95 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #a6da95 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #a6da95 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #a6da95 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #a6da95 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #a6da95 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #a6da95 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Green/userContent.css
+++ b/themes/Macchiato/Green/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #a6da95 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Lavender/userChrome.css
+++ b/themes/Macchiato/Lavender/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Lavender/userChrome.css
+++ b/themes/Macchiato/Lavender/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Lavender/userChrome.css
+++ b/themes/Macchiato/Lavender/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Lavender/userChrome.css
+++ b/themes/Macchiato/Lavender/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #b7bdf8 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Lavender/userContent.css
+++ b/themes/Macchiato/Lavender/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #b7bdf8 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Lavender/userContent.css
+++ b/themes/Macchiato/Lavender/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #b7bdf8 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #b7bdf8 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #b7bdf8 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #b7bdf8 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #b7bdf8 24%, #363a4f) !important;
+      --button-background-color-primary: #b7bdf8 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #b7bdf8 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #b7bdf8 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #b7bdf8 !important;
+      --button-border-color-primary: #b7bdf8 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #b7bdf8 !important;
+      --color-accent-primary-hover: rgb(208, 212, 250) !important;
+      --color-accent-primary-active: rgb(194, 184, 248) !important;
+      --focus-outline-color: #b7bdf8 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #b7bdf8 !important;
+      --link-color-active: rgb(194, 184, 248) !important;
       --link-color-hover: rgb(208, 212, 250) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #b7bdf8 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #b7bdf8 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #b7bdf8 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #b7bdf8 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #b7bdf8 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #b7bdf8 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #b7bdf8 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #b7bdf8 22%, #363a4f) !important;
+      --in-content-primary-button-background: #b7bdf8 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #b7bdf8 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #b7bdf8 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #b7bdf8 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #b7bdf8 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #b7bdf8 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #b7bdf8 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #b7bdf8 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #b7bdf8 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #b7bdf8 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #b7bdf8 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #b7bdf8 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #b7bdf8 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #b7bdf8 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Maroon/userChrome.css
+++ b/themes/Macchiato/Maroon/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Maroon/userChrome.css
+++ b/themes/Macchiato/Maroon/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Maroon/userChrome.css
+++ b/themes/Macchiato/Maroon/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Maroon/userChrome.css
+++ b/themes/Macchiato/Maroon/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #ee99a0 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Maroon/userContent.css
+++ b/themes/Macchiato/Maroon/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #ee99a0 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Maroon/userContent.css
+++ b/themes/Macchiato/Maroon/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #ee99a0 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #ee99a0 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #ee99a0 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #ee99a0 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #ee99a0 24%, #363a4f) !important;
+      --button-background-color-primary: #ee99a0 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #ee99a0 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #ee99a0 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #ee99a0 !important;
+      --button-border-color-primary: #ee99a0 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #ee99a0 !important;
+      --color-accent-primary-hover: rgb(242, 176, 182) !important;
+      --color-accent-primary-active: rgb(238, 168, 154) !important;
+      --focus-outline-color: #ee99a0 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #ee99a0 !important;
+      --link-color-active: rgb(238, 168, 154) !important;
       --link-color-hover: rgb(242, 176, 182) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #ee99a0 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #ee99a0 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #ee99a0 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ee99a0 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ee99a0 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #ee99a0 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #ee99a0 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #ee99a0 22%, #363a4f) !important;
+      --in-content-primary-button-background: #ee99a0 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #ee99a0 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #ee99a0 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #ee99a0 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #ee99a0 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #ee99a0 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #ee99a0 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ee99a0 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ee99a0 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #ee99a0 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #ee99a0 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #ee99a0 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #ee99a0 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #ee99a0 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Mauve/userChrome.css
+++ b/themes/Macchiato/Mauve/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Mauve/userChrome.css
+++ b/themes/Macchiato/Mauve/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #c6a0f6 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Mauve/userChrome.css
+++ b/themes/Macchiato/Mauve/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Mauve/userChrome.css
+++ b/themes/Macchiato/Mauve/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Mauve/userContent.css
+++ b/themes/Macchiato/Mauve/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #c6a0f6 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #c6a0f6 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #c6a0f6 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #c6a0f6 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #c6a0f6 24%, #363a4f) !important;
+      --button-background-color-primary: #c6a0f6 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #c6a0f6 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #c6a0f6 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #c6a0f6 !important;
+      --button-border-color-primary: #c6a0f6 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #c6a0f6 !important;
+      --color-accent-primary-hover: rgb(213, 184, 248) !important;
+      --color-accent-primary-active: rgb(220, 160, 246) !important;
+      --focus-outline-color: #c6a0f6 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #c6a0f6 !important;
+      --link-color-active: rgb(220, 160, 246) !important;
       --link-color-hover: rgb(213, 184, 248) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #c6a0f6 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #c6a0f6 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #c6a0f6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #c6a0f6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #c6a0f6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #c6a0f6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #c6a0f6 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #c6a0f6 22%, #363a4f) !important;
+      --in-content-primary-button-background: #c6a0f6 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #c6a0f6 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #c6a0f6 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #c6a0f6 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #c6a0f6 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #c6a0f6 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #c6a0f6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #c6a0f6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #c6a0f6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #c6a0f6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #c6a0f6 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #c6a0f6 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #c6a0f6 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #c6a0f6 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Mauve/userContent.css
+++ b/themes/Macchiato/Mauve/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #c6a0f6 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Peach/userChrome.css
+++ b/themes/Macchiato/Peach/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Peach/userChrome.css
+++ b/themes/Macchiato/Peach/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Peach/userChrome.css
+++ b/themes/Macchiato/Peach/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Peach/userChrome.css
+++ b/themes/Macchiato/Peach/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #f5a97f !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Peach/userContent.css
+++ b/themes/Macchiato/Peach/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f5a97f 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f5a97f 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #f5a97f !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f5a97f 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #f5a97f 24%, #363a4f) !important;
+      --button-background-color-primary: #f5a97f !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f5a97f 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f5a97f 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #f5a97f !important;
+      --button-border-color-primary: #f5a97f !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #f5a97f !important;
+      --color-accent-primary-hover: rgb(247, 185, 151) !important;
+      --color-accent-primary-active: rgb(245, 198, 127) !important;
+      --focus-outline-color: #f5a97f !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #f5a97f !important;
+      --link-color-active: rgb(245, 198, 127) !important;
       --link-color-hover: rgb(247, 185, 151) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f5a97f !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f5a97f 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f5a97f !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5a97f 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5a97f 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f5a97f !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #f5a97f !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #f5a97f 22%, #363a4f) !important;
+      --in-content-primary-button-background: #f5a97f !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f5a97f 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f5a97f 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #f5a97f !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f5a97f !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f5a97f !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f5a97f !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5a97f 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5a97f 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f5a97f !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #f5a97f !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #f5a97f !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f5a97f 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f5a97f !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Peach/userContent.css
+++ b/themes/Macchiato/Peach/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f5a97f !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Pink/userChrome.css
+++ b/themes/Macchiato/Pink/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Pink/userChrome.css
+++ b/themes/Macchiato/Pink/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Pink/userChrome.css
+++ b/themes/Macchiato/Pink/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Pink/userChrome.css
+++ b/themes/Macchiato/Pink/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #f5bde6 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Pink/userContent.css
+++ b/themes/Macchiato/Pink/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f5bde6 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f5bde6 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #f5bde6 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f5bde6 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #f5bde6 24%, #363a4f) !important;
+      --button-background-color-primary: #f5bde6 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f5bde6 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f5bde6 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #f5bde6 !important;
+      --button-border-color-primary: #f5bde6 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #f5bde6 !important;
+      --color-accent-primary-hover: rgb(248, 212, 239) !important;
+      --color-accent-primary-active: rgb(245, 189, 216) !important;
+      --focus-outline-color: #f5bde6 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #f5bde6 !important;
+      --link-color-active: rgb(245, 189, 216) !important;
       --link-color-hover: rgb(248, 212, 239) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f5bde6 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f5bde6 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f5bde6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5bde6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5bde6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f5bde6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #f5bde6 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #f5bde6 22%, #363a4f) !important;
+      --in-content-primary-button-background: #f5bde6 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f5bde6 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f5bde6 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #f5bde6 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f5bde6 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f5bde6 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f5bde6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5bde6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5bde6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f5bde6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #f5bde6 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #f5bde6 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f5bde6 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f5bde6 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Pink/userContent.css
+++ b/themes/Macchiato/Pink/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f5bde6 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Red/userChrome.css
+++ b/themes/Macchiato/Red/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Red/userChrome.css
+++ b/themes/Macchiato/Red/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #ed8796 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Red/userChrome.css
+++ b/themes/Macchiato/Red/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Red/userChrome.css
+++ b/themes/Macchiato/Red/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Red/userContent.css
+++ b/themes/Macchiato/Red/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #ed8796 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #ed8796 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #ed8796 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #ed8796 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #ed8796 24%, #363a4f) !important;
+      --button-background-color-primary: #ed8796 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #ed8796 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #ed8796 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #ed8796 !important;
+      --button-border-color-primary: #ed8796 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #ed8796 !important;
+      --color-accent-primary-hover: rgb(240, 158, 170) !important;
+      --color-accent-primary-active: rgb(237, 145, 135) !important;
+      --focus-outline-color: #ed8796 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #ed8796 !important;
+      --link-color-active: rgb(237, 145, 135) !important;
       --link-color-hover: rgb(240, 158, 170) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #ed8796 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #ed8796 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #ed8796 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ed8796 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ed8796 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #ed8796 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #ed8796 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #ed8796 22%, #363a4f) !important;
+      --in-content-primary-button-background: #ed8796 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #ed8796 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #ed8796 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #ed8796 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #ed8796 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #ed8796 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #ed8796 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #ed8796 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #ed8796 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #ed8796 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #ed8796 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #ed8796 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #ed8796 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #ed8796 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Red/userContent.css
+++ b/themes/Macchiato/Red/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #ed8796 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Rosewater/userChrome.css
+++ b/themes/Macchiato/Rosewater/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Rosewater/userChrome.css
+++ b/themes/Macchiato/Rosewater/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Rosewater/userChrome.css
+++ b/themes/Macchiato/Rosewater/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #f4dbd6 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Rosewater/userChrome.css
+++ b/themes/Macchiato/Rosewater/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Rosewater/userContent.css
+++ b/themes/Macchiato/Rosewater/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f4dbd6 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Rosewater/userContent.css
+++ b/themes/Macchiato/Rosewater/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f4dbd6 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f4dbd6 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #f4dbd6 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f4dbd6 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #f4dbd6 24%, #363a4f) !important;
+      --button-background-color-primary: #f4dbd6 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f4dbd6 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f4dbd6 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #f4dbd6 !important;
+      --button-border-color-primary: #f4dbd6 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #f4dbd6 !important;
+      --color-accent-primary-hover: rgb(249, 237, 235) !important;
+      --color-accent-primary-active: rgb(244, 227, 214) !important;
+      --focus-outline-color: #f4dbd6 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #f4dbd6 !important;
+      --link-color-active: rgb(244, 227, 214) !important;
       --link-color-hover: rgb(249, 237, 235) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f4dbd6 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f4dbd6 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f4dbd6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f4dbd6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f4dbd6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f4dbd6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #f4dbd6 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #f4dbd6 22%, #363a4f) !important;
+      --in-content-primary-button-background: #f4dbd6 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f4dbd6 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f4dbd6 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #f4dbd6 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f4dbd6 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #f4dbd6 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #f4dbd6 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f4dbd6 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f4dbd6 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #f4dbd6 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #f4dbd6 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #f4dbd6 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f4dbd6 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f4dbd6 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Sapphire/userChrome.css
+++ b/themes/Macchiato/Sapphire/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Sapphire/userChrome.css
+++ b/themes/Macchiato/Sapphire/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Sapphire/userChrome.css
+++ b/themes/Macchiato/Sapphire/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Sapphire/userChrome.css
+++ b/themes/Macchiato/Sapphire/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #7dc4e4 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Sapphire/userContent.css
+++ b/themes/Macchiato/Sapphire/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #7dc4e4 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #7dc4e4 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #7dc4e4 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #7dc4e4 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #7dc4e4 24%, #363a4f) !important;
+      --button-background-color-primary: #7dc4e4 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #7dc4e4 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #7dc4e4 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #7dc4e4 !important;
+      --button-border-color-primary: #7dc4e4 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #7dc4e4 !important;
+      --color-accent-primary-hover: rgb(147, 206, 233) !important;
+      --color-accent-primary-active: rgb(126, 170, 228) !important;
+      --focus-outline-color: #7dc4e4 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #7dc4e4 !important;
+      --link-color-active: rgb(126, 170, 228) !important;
       --link-color-hover: rgb(147, 206, 233) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #7dc4e4 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #7dc4e4 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #7dc4e4 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #7dc4e4 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #7dc4e4 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #7dc4e4 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #7dc4e4 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #7dc4e4 22%, #363a4f) !important;
+      --in-content-primary-button-background: #7dc4e4 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #7dc4e4 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #7dc4e4 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #7dc4e4 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #7dc4e4 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #7dc4e4 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #7dc4e4 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #7dc4e4 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #7dc4e4 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #7dc4e4 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #7dc4e4 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #7dc4e4 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #7dc4e4 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #7dc4e4 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Sapphire/userContent.css
+++ b/themes/Macchiato/Sapphire/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #7dc4e4 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Sky/userChrome.css
+++ b/themes/Macchiato/Sky/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Sky/userChrome.css
+++ b/themes/Macchiato/Sky/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Sky/userChrome.css
+++ b/themes/Macchiato/Sky/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Sky/userChrome.css
+++ b/themes/Macchiato/Sky/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #91d7e3 !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Sky/userContent.css
+++ b/themes/Macchiato/Sky/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #91d7e3 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #91d7e3 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #91d7e3 !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #91d7e3 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #91d7e3 24%, #363a4f) !important;
+      --button-background-color-primary: #91d7e3 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #91d7e3 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #91d7e3 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #91d7e3 !important;
+      --button-border-color-primary: #91d7e3 !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #91d7e3 !important;
+      --color-accent-primary-hover: rgb(166, 222, 232) !important;
+      --color-accent-primary-active: rgb(145, 194, 227) !important;
+      --focus-outline-color: #91d7e3 !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #91d7e3 !important;
+      --link-color-active: rgb(145, 194, 227) !important;
       --link-color-hover: rgb(166, 222, 232) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #91d7e3 !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #91d7e3 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #91d7e3 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #91d7e3 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #91d7e3 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #91d7e3 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #91d7e3 !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #91d7e3 22%, #363a4f) !important;
+      --in-content-primary-button-background: #91d7e3 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #91d7e3 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #91d7e3 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #91d7e3 !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #91d7e3 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #91d7e3 !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #91d7e3 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #91d7e3 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #91d7e3 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #91d7e3 !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #91d7e3 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #91d7e3 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #91d7e3 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #91d7e3 !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Sky/userContent.css
+++ b/themes/Macchiato/Sky/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #91d7e3 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Teal/userChrome.css
+++ b/themes/Macchiato/Teal/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Teal/userChrome.css
+++ b/themes/Macchiato/Teal/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Teal/userChrome.css
+++ b/themes/Macchiato/Teal/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #8bd5ca !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Teal/userChrome.css
+++ b/themes/Macchiato/Teal/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Teal/userContent.css
+++ b/themes/Macchiato/Teal/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #8bd5ca 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #8bd5ca 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #8bd5ca !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #8bd5ca 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #8bd5ca 24%, #363a4f) !important;
+      --button-background-color-primary: #8bd5ca !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #8bd5ca 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #8bd5ca 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #8bd5ca !important;
+      --button-border-color-primary: #8bd5ca !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #8bd5ca !important;
+      --color-accent-primary-hover: rgb(158, 220, 211) !important;
+      --color-accent-primary-active: rgb(139, 205, 213) !important;
+      --focus-outline-color: #8bd5ca !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #8bd5ca !important;
+      --link-color-active: rgb(139, 205, 213) !important;
       --link-color-hover: rgb(158, 220, 211) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #8bd5ca !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #8bd5ca 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #8bd5ca !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8bd5ca 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8bd5ca 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #8bd5ca !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #8bd5ca !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #8bd5ca 22%, #363a4f) !important;
+      --in-content-primary-button-background: #8bd5ca !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #8bd5ca 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #8bd5ca 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #8bd5ca !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #8bd5ca !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #8bd5ca !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #8bd5ca !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #8bd5ca 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #8bd5ca 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #8bd5ca !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #8bd5ca !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #8bd5ca !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #8bd5ca 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #8bd5ca !important;
     }
 
     .identity-color-blue {

--- a/themes/Macchiato/Teal/userContent.css
+++ b/themes/Macchiato/Teal/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #8bd5ca !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Yellow/userChrome.css
+++ b/themes/Macchiato/Yellow/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #1e2030 !important;
     --zen-main-browser-background: #1e2030 !important;
     --toolbox-bgcolor-inactive: #1e2030 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #c6a0f6 !important;
   }
 
-  hbox#titlebar {
-    background-color: #1e2030 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #1e2030;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #1e2030 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #1e2030 !important;
-    background-color: #1e2030 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #363a4f !important;
-    background-color: #363a4f !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
-      --zen-main-browser-background-toolbar: #1e2030 !important;
-      --zen-main-browser-background-old: #1e2030 !important;
-      --zen-main-browser-background-toolbar-old: #1e2030 !important;
-      --zen-navigator-toolbox-background: #1e2030 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Macchiato/Yellow/userChrome.css
+++ b/themes/Macchiato/Yellow/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #1e2030 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #24273a !important;
+    --catppuccin-quit-dialog-fg: #cad3f5 !important;
+    --catppuccin-quit-dialog-accent: #eed49f !important;
+    --catppuccin-quit-dialog-button-bg: #363a4f !important;
+    --catppuccin-quit-dialog-button-bg-hover: #494d64 !important;
+    --catppuccin-quit-dialog-button-bg-active: #5b6078 !important;
+    --catppuccin-quit-dialog-button-border: #5b6078 !important;
+    --catppuccin-quit-dialog-muted: #a5adcb !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #1e2030 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #1e2030;
@@ -179,9 +189,118 @@
     background-color: #1e2030 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Macchiato/Yellow/userChrome.css
+++ b/themes/Macchiato/Yellow/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #1e2030 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Macchiato base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #1e2030 !important;
+    background-color: #1e2030 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #363a4f !important;
+    background-color: #363a4f !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #1e2030 !important;
+      --zen-main-browser-background-toolbar: #1e2030 !important;
+      --zen-main-browser-background-old: #1e2030 !important;
+      --zen-main-browser-background-toolbar-old: #1e2030 !important;
+      --zen-navigator-toolbox-background: #1e2030 !important;
+    }
+  }
 }

--- a/themes/Macchiato/Yellow/userChrome.css
+++ b/themes/Macchiato/Yellow/userChrome.css
@@ -40,6 +40,50 @@
     color: #1e2030 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    --lwt-sidebar-background-color: #24273a !important;
+    --lwt-sidebar-text-color: #cad3f5 !important;
+    background: #24273a !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #24273a !important;
+    --lwt-toolbar-field-focus: #24273a !important;
+    --lwt-toolbar-field-border-color: #24273a !important;
+    border-color: #24273a !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #24273a !important;
+    --sidebar-text-color: #cad3f5 !important;
+    --sidebar-border-color: #24273a !important;
+    background: #24273a !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #24273a !important;
   }

--- a/themes/Macchiato/Yellow/userContent.css
+++ b/themes/Macchiato/Yellow/userContent.css
@@ -202,6 +202,12 @@
       color: #cad3f5 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #363a4f !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #eed49f !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Macchiato/Yellow/userContent.css
+++ b/themes/Macchiato/Yellow/userContent.css
@@ -63,27 +63,286 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #1e2030 !important;
-      --in-content-text-color: #cad3f5 !important;
+      --background-color-canvas: #181926 !important;
+      --background-color-box: #24273a !important;
+      --background-color-box-info: #363a4f !important;
+      --background-color-critical: color-mix(in srgb, #ed8796 18%, #24273a) !important;
+      --background-color-information: color-mix(in srgb, #8aadf4 18%, #24273a) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #eed49f 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #eed49f 26%, #363a4f) !important;
+      --background-color-success: color-mix(in srgb, #a6da95 18%, #24273a) !important;
+      --background-color-warning: color-mix(in srgb, #eed49f 18%, #24273a) !important;
+      --border-color: #494d64 !important;
+      --border-color-deemphasized: #363a4f !important;
+      --border-color-interactive: #5b6078 !important;
+      --border-color-interactive-hover: #6e738d !important;
+      --border-color-interactive-active: #8087a2 !important;
+      --border-color-selected: #eed49f !important;
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #eed49f 24%, #363a4f) !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+      --button-background-color: #363a4f !important;
+      --button-background-color-hover: #494d64 !important;
+      --button-background-color-active: #5b6078 !important;
+      --button-background-color-selected: color-mix(in srgb, #eed49f 24%, #363a4f) !important;
+      --button-background-color-primary: #eed49f !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #eed49f 86%, #cad3f5) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #eed49f 94%, #24273a) !important;
+      --button-border-color: #494d64 !important;
+      --button-border-color-hover: #5b6078 !important;
+      --button-border-color-active: #eed49f !important;
+      --button-border-color-primary: #eed49f !important;
+      --button-text-color: #cad3f5 !important;
+      --button-text-color-hover: #cad3f5 !important;
+      --button-text-color-active: #cad3f5 !important;
+      --button-text-color-primary: #181926 !important;
+      --button-text-color-primary-hover: #181926 !important;
+      --button-text-color-primary-active: #181926 !important;
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+      --color-accent-primary: #eed49f !important;
+      --color-accent-primary-hover: rgb(242, 222, 182) !important;
+      --color-accent-primary-active: rgb(238, 232, 160) !important;
+      --focus-outline-color: #eed49f !important;
+      --icon-color: #b8c0e0 !important;
+      --icon-color-critical: #ed8796 !important;
+      --icon-color-information: #8aadf4 !important;
+      --icon-color-success: #a6da95 !important;
+      --icon-color-warning: #eed49f !important;
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
       --link-color: #eed49f !important;
+      --link-color-active: rgb(238, 232, 160) !important;
       --link-color-hover: rgb(242, 222, 182) !important;
-      --zen-colors-primary: #363a4f !important;
+      --link-color-visited: #c6a0f6 !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #eed49f !important;
+      --select-text-color: #cad3f5 !important;
+      --table-row-background-color-alternate: #1e2030 !important;
+      --table-row-background-color-hover: #363a4f !important;
+      --table-row-background-color-selected: color-mix(in srgb, #eed49f 24%, #363a4f) !important;
+      --text-color: #cad3f5 !important;
+      --text-color-deemphasized: #b8c0e0 !important;
+      --text-color-disabled: #6e738d !important;
+      --text-color-error: #ed8796 !important;
+      --text-color-success: #a6da95 !important;
+      --text-color-warning: #eed49f !important;
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #eed49f !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #eed49f 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #eed49f 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #eed49f !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+      --zen-colors-tertiary: #1e2030 !important;
+      --zen-colors-border: #494d64 !important;
+      --zen-colors-hover-bg: #363a4f !important;
+      --in-content-text-color: #cad3f5 !important;
+      --in-content-page-background: #181926 !important;
+      --in-content-page-color: #cad3f5 !important;
       --in-content-box-background: #363a4f !important;
+      --in-content-box-background-odd: #1e2030 !important;
+      --in-content-box-border-color: #494d64 !important;
+      --in-content-border-color: #494d64 !important;
+      --in-content-button-background: #363a4f !important;
+      --in-content-button-background-hover: #494d64 !important;
+      --in-content-button-background-active: #5b6078 !important;
+      --in-content-button-border-color: #494d64 !important;
+      --in-content-button-border-color-hover: #5b6078 !important;
+      --in-content-button-border-color-active: #eed49f !important;
+      --in-content-button-text-color: #cad3f5 !important;
+      --in-content-deemphasized-text: #b8c0e0 !important;
+      --in-content-item-hover: #363a4f !important;
+      --in-content-item-selected: color-mix(in srgb, #eed49f 22%, #363a4f) !important;
+      --in-content-primary-button-background: #eed49f !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #eed49f 86%, #cad3f5) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #eed49f 94%, #24273a) !important;
+      --in-content-primary-button-text-color: #181926 !important;
+      --zen-colors-primary: #363a4f !important;
       --zen-primary-color: #eed49f !important;
     }
 
-    groupbox , moz-card{
-      background: #24273a !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #363a4f !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #181926 !important;
       color: #cad3f5 !important;
     }
 
-    .main-content {
-      background-color: #181926 !important;
+    .navigation {
+      background: #1e2030 !important;
+      color: #cad3f5 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #363a4f !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #eed49f !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #24273a !important;
+      border: 1px solid #494d64 !important;
+      box-shadow: none !important;
+      color: #cad3f5 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #24273a !important;
+      --card-border-color: #494d64 !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #5b6078 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #24273a !important;
+      --box-border-color: #494d64 !important;
+      --box-button-background-color: #363a4f !important;
+      --box-button-background-color-hover: #494d64 !important;
+      --box-button-background-color-active: #5b6078 !important;
+      --box-button-text-color: #cad3f5 !important;
+      --box-icon-color: #b8c0e0 !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #1e2030 !important;
+      --input-text-border-color: #5b6078 !important;
+      --input-text-color: #cad3f5 !important;
+      --input-text-placeholder-color: #a5adcb !important;
+      --select-background-color: #363a4f !important;
+      --select-background-color-hover: #494d64 !important;
+      --select-background-color-active: #5b6078 !important;
+      --select-border-color: #494d64 !important;
+      --select-border-color-hover: #5b6078 !important;
+      --select-border-color-active: #eed49f !important;
+      --select-text-color: #cad3f5 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #494d64 !important;
+      --toggle-background-color-hover: #5b6078 !important;
+      --toggle-background-color-pressed: #eed49f !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #eed49f 86%, #cad3f5) !important;
+      --toggle-dot-background-color: #cad3f5 !important;
+      --toggle-dot-background-color-on-pressed: #181926 !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #24273a !important;
+      --visual-picker-item-background-color-hover: #363a4f !important;
+      --visual-picker-item-background-color-active: #494d64 !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #eed49f 16%, #363a4f) !important;
+      --visual-picker-item-border-color: #494d64 !important;
+      --visual-picker-item-border-color-hover: #5b6078 !important;
+      --visual-picker-item-border-color-selected: #eed49f !important;
+      --visual-picker-item-check-icon-color: #181926 !important;
+      --visual-picker-item-icon-color: #b8c0e0 !important;
+      --visual-picker-item-text-color: #cad3f5 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #363a4f !important;
+      color: #cad3f5 !important;
+      border-color: #494d64 !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #5b6078 !important;
+      border-color: #eed49f !important;
+    }
+
+    .zenCKSOption-input {
+      background: #363a4f !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #494d64 !important;
+      border-color: #5b6078 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #1e2030 !important;
+      border-color: #eed49f !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #eed49f 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #363a4f !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #24273a !important;
+      border-color: #494d64 !important;
+      color: #cad3f5 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #363a4f !important;
+      border-color: #5b6078 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #363a4f !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #eed49f !important;
     }
 
     .identity-color-blue {

--- a/themes/Mocha/Blue/userChrome.css
+++ b/themes/Mocha/Blue/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Blue/userChrome.css
+++ b/themes/Mocha/Blue/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #89b4fa !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Blue/userChrome.css
+++ b/themes/Mocha/Blue/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Blue/userChrome.css
+++ b/themes/Mocha/Blue/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Blue/userContent.css
+++ b/themes/Mocha/Blue/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #89b4fa !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Blue/userContent.css
+++ b/themes/Mocha/Blue/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #89b4fa 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #89b4fa 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #89b4fa !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #89b4fa 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #89b4fa 24%, #313244) !important;
+      --button-background-color-primary: #89b4fa !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #89b4fa 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #89b4fa 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #89b4fa !important;
+      --button-border-color-primary: #89b4fa !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #89b4fa !important;
+      --color-accent-primary-hover: rgb(163, 197, 251) !important;
+      --color-accent-primary-active: rgb(138, 153, 250) !important;
+      --focus-outline-color: #89b4fa !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #89b4fa !important;
+      --link-color-active: rgb(138, 153, 250) !important;
       --link-color-hover: rgb(163, 197, 251) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #89b4fa !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #89b4fa 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #89b4fa !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #89b4fa 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #89b4fa 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #89b4fa !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #89b4fa !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #89b4fa 22%, #313244) !important;
+      --in-content-primary-button-background: #89b4fa !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #89b4fa 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #89b4fa 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #89b4fa !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #89b4fa !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #89b4fa !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #89b4fa !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #89b4fa 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #89b4fa 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #89b4fa !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #89b4fa !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #89b4fa !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #89b4fa 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #89b4fa !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Flamingo/userChrome.css
+++ b/themes/Mocha/Flamingo/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Flamingo/userChrome.css
+++ b/themes/Mocha/Flamingo/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Flamingo/userChrome.css
+++ b/themes/Mocha/Flamingo/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #f2cdcd !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Flamingo/userChrome.css
+++ b/themes/Mocha/Flamingo/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Flamingo/userContent.css
+++ b/themes/Mocha/Flamingo/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f2cdcd 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f2cdcd 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #f2cdcd !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f2cdcd 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #f2cdcd 24%, #313244) !important;
+      --button-background-color-primary: #f2cdcd !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f2cdcd 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f2cdcd 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #f2cdcd !important;
+      --button-border-color-primary: #f2cdcd !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #f2cdcd !important;
+      --color-accent-primary-hover: rgb(248, 226, 226) !important;
+      --color-accent-primary-active: rgb(242, 215, 206) !important;
+      --focus-outline-color: #f2cdcd !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #f2cdcd !important;
+      --link-color-active: rgb(242, 215, 206) !important;
       --link-color-hover: rgb(248, 226, 226) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f2cdcd !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f2cdcd 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f2cdcd !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f2cdcd 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f2cdcd 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f2cdcd !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #f2cdcd !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #f2cdcd 22%, #313244) !important;
+      --in-content-primary-button-background: #f2cdcd !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f2cdcd 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f2cdcd 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #f2cdcd !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f2cdcd !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f2cdcd !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f2cdcd !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f2cdcd 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f2cdcd 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f2cdcd !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #f2cdcd !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #f2cdcd !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f2cdcd 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f2cdcd !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Flamingo/userContent.css
+++ b/themes/Mocha/Flamingo/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f2cdcd !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Green/userChrome.css
+++ b/themes/Mocha/Green/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Green/userChrome.css
+++ b/themes/Mocha/Green/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #a6e3a1 !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Green/userChrome.css
+++ b/themes/Mocha/Green/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Green/userChrome.css
+++ b/themes/Mocha/Green/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Green/userContent.css
+++ b/themes/Mocha/Green/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #a6e3a1 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #a6e3a1 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #a6e3a1 !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #a6e3a1 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #a6e3a1 24%, #313244) !important;
+      --button-background-color-primary: #a6e3a1 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #a6e3a1 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #a6e3a1 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #a6e3a1 !important;
+      --button-border-color-primary: #a6e3a1 !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #a6e3a1 !important;
+      --color-accent-primary-hover: rgb(185, 233, 181) !important;
+      --color-accent-primary-active: rgb(161, 227, 172) !important;
+      --focus-outline-color: #a6e3a1 !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #a6e3a1 !important;
+      --link-color-active: rgb(161, 227, 172) !important;
       --link-color-hover: rgb(185, 233, 181) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #a6e3a1 !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #a6e3a1 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #a6e3a1 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #a6e3a1 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #a6e3a1 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #a6e3a1 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #a6e3a1 !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #a6e3a1 22%, #313244) !important;
+      --in-content-primary-button-background: #a6e3a1 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #a6e3a1 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #a6e3a1 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #a6e3a1 !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #a6e3a1 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #a6e3a1 !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #a6e3a1 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #a6e3a1 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #a6e3a1 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #a6e3a1 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #a6e3a1 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #a6e3a1 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #a6e3a1 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #a6e3a1 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Green/userContent.css
+++ b/themes/Mocha/Green/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #a6e3a1 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Lavender/userChrome.css
+++ b/themes/Mocha/Lavender/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Lavender/userChrome.css
+++ b/themes/Mocha/Lavender/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Lavender/userChrome.css
+++ b/themes/Mocha/Lavender/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Lavender/userChrome.css
+++ b/themes/Mocha/Lavender/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #b4befe !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Lavender/userContent.css
+++ b/themes/Mocha/Lavender/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #b4befe !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Lavender/userContent.css
+++ b/themes/Mocha/Lavender/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #b4befe 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #b4befe 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #b4befe !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #b4befe 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #b4befe 24%, #313244) !important;
+      --button-background-color-primary: #b4befe !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #b4befe 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #b4befe 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #b4befe !important;
+      --button-border-color-primary: #b4befe !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #b4befe !important;
+      --color-accent-primary-hover: rgb(206, 212, 254) !important;
+      --color-accent-primary-active: rgb(189, 180, 254) !important;
+      --focus-outline-color: #b4befe !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #b4befe !important;
+      --link-color-active: rgb(189, 180, 254) !important;
       --link-color-hover: rgb(206, 212, 254) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #b4befe !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #b4befe 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #b4befe !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #b4befe 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #b4befe 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #b4befe !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #b4befe !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #b4befe 22%, #313244) !important;
+      --in-content-primary-button-background: #b4befe !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #b4befe 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #b4befe 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #b4befe !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #b4befe !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #b4befe !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #b4befe !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #b4befe 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #b4befe 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #b4befe !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #b4befe !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #b4befe !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #b4befe 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #b4befe !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Maroon/userChrome.css
+++ b/themes/Mocha/Maroon/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Maroon/userChrome.css
+++ b/themes/Mocha/Maroon/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Maroon/userChrome.css
+++ b/themes/Mocha/Maroon/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Maroon/userChrome.css
+++ b/themes/Mocha/Maroon/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #eba0ac !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Maroon/userContent.css
+++ b/themes/Mocha/Maroon/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #eba0ac !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Maroon/userContent.css
+++ b/themes/Mocha/Maroon/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #eba0ac 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #eba0ac 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #eba0ac !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #eba0ac 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #eba0ac 24%, #313244) !important;
+      --button-background-color-primary: #eba0ac !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #eba0ac 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #eba0ac 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #eba0ac !important;
+      --button-border-color-primary: #eba0ac !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #eba0ac !important;
+      --color-accent-primary-hover: rgb(240, 182, 192) !important;
+      --color-accent-primary-active: rgb(235, 167, 161) !important;
+      --focus-outline-color: #eba0ac !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #eba0ac !important;
+      --link-color-active: rgb(235, 167, 161) !important;
       --link-color-hover: rgb(240, 182, 192) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #eba0ac !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #eba0ac 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #eba0ac !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #eba0ac 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #eba0ac 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #eba0ac !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #eba0ac !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #eba0ac 22%, #313244) !important;
+      --in-content-primary-button-background: #eba0ac !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #eba0ac 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #eba0ac 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #eba0ac !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #eba0ac !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #eba0ac !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #eba0ac !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #eba0ac 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #eba0ac 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #eba0ac !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #eba0ac !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #eba0ac !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #eba0ac 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #eba0ac !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Mauve/userChrome.css
+++ b/themes/Mocha/Mauve/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #cba6f7 !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Mauve/userContent.css
+++ b/themes/Mocha/Mauve/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #cba6f7 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Mauve/userContent.css
+++ b/themes/Mocha/Mauve/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #cba6f7 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #cba6f7 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #cba6f7 !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #cba6f7 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #cba6f7 24%, #313244) !important;
+      --button-background-color-primary: #cba6f7 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #cba6f7 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #cba6f7 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #cba6f7 !important;
+      --button-border-color-primary: #cba6f7 !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #cba6f7 !important;
+      --color-accent-primary-hover: rgb(217, 191, 249) !important;
+      --color-accent-primary-active: rgb(223, 167, 247) !important;
+      --focus-outline-color: #cba6f7 !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #cba6f7 !important;
+      --link-color-active: rgb(223, 167, 247) !important;
       --link-color-hover: rgb(217, 191, 249) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #cba6f7 !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #cba6f7 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #cba6f7 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #cba6f7 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #cba6f7 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #cba6f7 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #cba6f7 !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #cba6f7 22%, #313244) !important;
+      --in-content-primary-button-background: #cba6f7 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #cba6f7 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #cba6f7 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #cba6f7 !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #cba6f7 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #cba6f7 !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #cba6f7 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #cba6f7 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #cba6f7 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #cba6f7 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #cba6f7 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #cba6f7 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #cba6f7 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #cba6f7 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Peach/userChrome.css
+++ b/themes/Mocha/Peach/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Peach/userChrome.css
+++ b/themes/Mocha/Peach/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Peach/userChrome.css
+++ b/themes/Mocha/Peach/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Peach/userChrome.css
+++ b/themes/Mocha/Peach/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #fab387 !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Peach/userContent.css
+++ b/themes/Mocha/Peach/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #fab387 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Peach/userContent.css
+++ b/themes/Mocha/Peach/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #fab387 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #fab387 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #fab387 !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #fab387 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #fab387 24%, #313244) !important;
+      --button-background-color-primary: #fab387 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #fab387 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #fab387 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #fab387 !important;
+      --button-border-color-primary: #fab387 !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #fab387 !important;
+      --color-accent-primary-hover: rgb(251, 195, 161) !important;
+      --color-accent-primary-active: rgb(250, 208, 136) !important;
+      --focus-outline-color: #fab387 !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #fab387 !important;
+      --link-color-active: rgb(250, 208, 136) !important;
       --link-color-hover: rgb(251, 195, 161) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #fab387 !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #fab387 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #fab387 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #fab387 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #fab387 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #fab387 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #fab387 !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #fab387 22%, #313244) !important;
+      --in-content-primary-button-background: #fab387 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #fab387 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #fab387 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #fab387 !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #fab387 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #fab387 !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #fab387 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #fab387 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #fab387 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #fab387 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #fab387 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #fab387 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #fab387 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #fab387 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Pink/userChrome.css
+++ b/themes/Mocha/Pink/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Pink/userChrome.css
+++ b/themes/Mocha/Pink/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #f5c2e7 !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Pink/userChrome.css
+++ b/themes/Mocha/Pink/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Pink/userChrome.css
+++ b/themes/Mocha/Pink/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Pink/userContent.css
+++ b/themes/Mocha/Pink/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f5c2e7 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Pink/userContent.css
+++ b/themes/Mocha/Pink/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f5c2e7 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f5c2e7 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #f5c2e7 !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f5c2e7 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #f5c2e7 24%, #313244) !important;
+      --button-background-color-primary: #f5c2e7 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f5c2e7 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f5c2e7 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #f5c2e7 !important;
+      --button-border-color-primary: #f5c2e7 !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #f5c2e7 !important;
+      --color-accent-primary-hover: rgb(249, 217, 240) !important;
+      --color-accent-primary-active: rgb(245, 195, 219) !important;
+      --focus-outline-color: #f5c2e7 !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #f5c2e7 !important;
+      --link-color-active: rgb(245, 195, 219) !important;
       --link-color-hover: rgb(249, 217, 240) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f5c2e7 !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f5c2e7 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f5c2e7 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5c2e7 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5c2e7 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f5c2e7 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #f5c2e7 !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #f5c2e7 22%, #313244) !important;
+      --in-content-primary-button-background: #f5c2e7 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f5c2e7 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f5c2e7 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #f5c2e7 !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f5c2e7 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f5c2e7 !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f5c2e7 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5c2e7 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5c2e7 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f5c2e7 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #f5c2e7 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #f5c2e7 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f5c2e7 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f5c2e7 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Red/userChrome.css
+++ b/themes/Mocha/Red/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Red/userChrome.css
+++ b/themes/Mocha/Red/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #f38ba8 !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Red/userChrome.css
+++ b/themes/Mocha/Red/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Red/userChrome.css
+++ b/themes/Mocha/Red/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Red/userContent.css
+++ b/themes/Mocha/Red/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f38ba8 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Red/userContent.css
+++ b/themes/Mocha/Red/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f38ba8 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f38ba8 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #f38ba8 !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f38ba8 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #f38ba8 24%, #313244) !important;
+      --button-background-color-primary: #f38ba8 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f38ba8 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f38ba8 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #f38ba8 !important;
+      --button-border-color-primary: #f38ba8 !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #f38ba8 !important;
+      --color-accent-primary-hover: rgb(245, 163, 186) !important;
+      --color-accent-primary-active: rgb(243, 139, 143) !important;
+      --focus-outline-color: #f38ba8 !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #f38ba8 !important;
+      --link-color-active: rgb(243, 139, 143) !important;
       --link-color-hover: rgb(245, 163, 186) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f38ba8 !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f38ba8 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f38ba8 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f38ba8 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f38ba8 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f38ba8 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #f38ba8 !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #f38ba8 22%, #313244) !important;
+      --in-content-primary-button-background: #f38ba8 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f38ba8 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f38ba8 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #f38ba8 !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f38ba8 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f38ba8 !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f38ba8 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f38ba8 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f38ba8 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f38ba8 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #f38ba8 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #f38ba8 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f38ba8 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f38ba8 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Rosewater/userChrome.css
+++ b/themes/Mocha/Rosewater/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Rosewater/userChrome.css
+++ b/themes/Mocha/Rosewater/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Rosewater/userChrome.css
+++ b/themes/Mocha/Rosewater/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Rosewater/userChrome.css
+++ b/themes/Mocha/Rosewater/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #f5e0dc !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Rosewater/userContent.css
+++ b/themes/Mocha/Rosewater/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f5e0dc !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Rosewater/userContent.css
+++ b/themes/Mocha/Rosewater/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f5e0dc 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f5e0dc 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #f5e0dc !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f5e0dc 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #f5e0dc 24%, #313244) !important;
+      --button-background-color-primary: #f5e0dc !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f5e0dc 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f5e0dc 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #f5e0dc !important;
+      --button-border-color-primary: #f5e0dc !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #f5e0dc !important;
+      --color-accent-primary-hover: rgb(251, 243, 241) !important;
+      --color-accent-primary-active: rgb(245, 231, 221) !important;
+      --focus-outline-color: #f5e0dc !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #f5e0dc !important;
+      --link-color-active: rgb(245, 231, 221) !important;
       --link-color-hover: rgb(251, 243, 241) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f5e0dc !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f5e0dc 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f5e0dc !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5e0dc 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5e0dc 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f5e0dc !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #f5e0dc !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #f5e0dc 22%, #313244) !important;
+      --in-content-primary-button-background: #f5e0dc !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f5e0dc 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f5e0dc 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #f5e0dc !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f5e0dc !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f5e0dc !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f5e0dc !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f5e0dc 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f5e0dc 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f5e0dc !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #f5e0dc !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #f5e0dc !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f5e0dc 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f5e0dc !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Sapphire/userChrome.css
+++ b/themes/Mocha/Sapphire/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Sapphire/userChrome.css
+++ b/themes/Mocha/Sapphire/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Sapphire/userChrome.css
+++ b/themes/Mocha/Sapphire/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Sapphire/userChrome.css
+++ b/themes/Mocha/Sapphire/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #74c7ec !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Sapphire/userContent.css
+++ b/themes/Mocha/Sapphire/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #74c7ec !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Sapphire/userContent.css
+++ b/themes/Mocha/Sapphire/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #74c7ec 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #74c7ec 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #74c7ec !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #74c7ec 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #74c7ec 24%, #313244) !important;
+      --button-background-color-primary: #74c7ec !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #74c7ec 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #74c7ec 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #74c7ec !important;
+      --button-border-color-primary: #74c7ec !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #74c7ec !important;
+      --color-accent-primary-hover: rgb(139, 207, 239) !important;
+      --color-accent-primary-active: rgb(116, 168, 236) !important;
+      --focus-outline-color: #74c7ec !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #74c7ec !important;
+      --link-color-active: rgb(116, 168, 236) !important;
       --link-color-hover: rgb(139, 207, 239) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #74c7ec !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #74c7ec 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #74c7ec !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #74c7ec 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #74c7ec 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #74c7ec !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #74c7ec !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #74c7ec 22%, #313244) !important;
+      --in-content-primary-button-background: #74c7ec !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #74c7ec 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #74c7ec 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #74c7ec !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #74c7ec !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #74c7ec !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #74c7ec !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #74c7ec 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #74c7ec 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #74c7ec !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #74c7ec !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #74c7ec !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #74c7ec 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #74c7ec !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Sky/userChrome.css
+++ b/themes/Mocha/Sky/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #89dceb !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Sky/userChrome.css
+++ b/themes/Mocha/Sky/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Sky/userChrome.css
+++ b/themes/Mocha/Sky/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Sky/userChrome.css
+++ b/themes/Mocha/Sky/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Sky/userContent.css
+++ b/themes/Mocha/Sky/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #89dceb 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #89dceb 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #89dceb !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #89dceb 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #89dceb 24%, #313244) !important;
+      --button-background-color-primary: #89dceb !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #89dceb 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #89dceb 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #89dceb !important;
+      --button-border-color-primary: #89dceb !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #89dceb !important;
+      --color-accent-primary-hover: rgb(159, 227, 239) !important;
+      --color-accent-primary-active: rgb(137, 196, 235) !important;
+      --focus-outline-color: #89dceb !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #89dceb !important;
+      --link-color-active: rgb(137, 196, 235) !important;
       --link-color-hover: rgb(159, 227, 239) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #89dceb !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #89dceb 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #89dceb !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #89dceb 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #89dceb 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #89dceb !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #89dceb !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #89dceb 22%, #313244) !important;
+      --in-content-primary-button-background: #89dceb !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #89dceb 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #89dceb 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #89dceb !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #89dceb !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #89dceb !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #89dceb !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #89dceb 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #89dceb 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #89dceb !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #89dceb !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #89dceb !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #89dceb 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #89dceb !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Sky/userContent.css
+++ b/themes/Mocha/Sky/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #89dceb !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Teal/userChrome.css
+++ b/themes/Mocha/Teal/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Teal/userChrome.css
+++ b/themes/Mocha/Teal/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Teal/userChrome.css
+++ b/themes/Mocha/Teal/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Teal/userChrome.css
+++ b/themes/Mocha/Teal/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #94e2d5 !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Teal/userContent.css
+++ b/themes/Mocha/Teal/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #94e2d5 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #94e2d5 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #94e2d5 !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #94e2d5 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #94e2d5 24%, #313244) !important;
+      --button-background-color-primary: #94e2d5 !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #94e2d5 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #94e2d5 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #94e2d5 !important;
+      --button-border-color-primary: #94e2d5 !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #94e2d5 !important;
+      --color-accent-primary-hover: rgb(169, 231, 221) !important;
+      --color-accent-primary-active: rgb(148, 219, 226) !important;
+      --focus-outline-color: #94e2d5 !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #94e2d5 !important;
+      --link-color-active: rgb(148, 219, 226) !important;
       --link-color-hover: rgb(169, 231, 221) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #94e2d5 !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #94e2d5 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #94e2d5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #94e2d5 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #94e2d5 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #94e2d5 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #94e2d5 !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #94e2d5 22%, #313244) !important;
+      --in-content-primary-button-background: #94e2d5 !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #94e2d5 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #94e2d5 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #94e2d5 !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #94e2d5 !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #94e2d5 !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #94e2d5 !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #94e2d5 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #94e2d5 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #94e2d5 !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #94e2d5 !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #94e2d5 !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #94e2d5 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #94e2d5 !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 

--- a/themes/Mocha/Teal/userContent.css
+++ b/themes/Mocha/Teal/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #94e2d5 !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Yellow/userChrome.css
+++ b/themes/Mocha/Yellow/userChrome.css
@@ -40,6 +40,50 @@
     color: #181825 !important;
   }
 
+  /* Keep the bookmarks slide-in panel on one flat background so the header
+   * strip doesn't read as a darker band above the tree.
+   */
+  #bookmarksPanel {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    --lwt-sidebar-background-color: #1e1e2e !important;
+    --lwt-sidebar-text-color: #cdd6f4 !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+  }
+
+  #bookmarksPanel #sidebar-panel-header,
+  #bookmarksPanel #sidebar-search-container,
+  #bookmarksPanel .sidebar-placesTree {
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
+  #bookmarksPanel #search-box {
+    --toolbar-field-focus-color: #1e1e2e !important;
+    --lwt-toolbar-field-focus: #1e1e2e !important;
+    --lwt-toolbar-field-border-color: #1e1e2e !important;
+    border-color: #1e1e2e !important;
+    box-shadow: none !important;
+  }
+
+  /* The host sidebar shell can paint its own darker backdrop, so force the
+   * bookmarks launcher container itself to the same color too.
+   */
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-box[sidebarcommand="viewBookmarksSidebar"] > *,
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"],
+  #sidebar-main[sidebarcommand="viewBookmarksSidebar"] > * {
+    --sidebar-background-color: #1e1e2e !important;
+    --sidebar-text-color: #cdd6f4 !important;
+    --sidebar-border-color: #1e1e2e !important;
+    background: #1e1e2e !important;
+    background-image: none !important;
+    box-shadow: none !important;
+  }
+
   .sidebar-placesTree {
     background-color: #1e1e2e !important;
   }

--- a/themes/Mocha/Yellow/userChrome.css
+++ b/themes/Mocha/Yellow/userChrome.css
@@ -127,4 +127,58 @@
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
+
+  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+
+  /* Remove system appearance so CSS backgrounds take effect */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background {
+    appearance: unset !important;
+    -moz-default-appearance: none !important;
+  }
+
+  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  #zen-main-app-wrapper,
+  #zen-appcontent-wrapper,
+  #zen-sidebar-splitter,
+  #zen-browser-background,
+  .zen-browser-generic-background,
+  .zen-toolbar-background,
+  #navigator-toolbox,
+  #tabbrowser-tabbox,
+  #main-window {
+    background: #181825 !important;
+    background-color: #181825 !important;
+  }
+
+  /* Style sidebar splitters */
+  #sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+  }
+
+  #zen-sidebar-splitter {
+    border: none !important;
+    background: #181825 !important;
+    background-color: #181825 !important;
+    opacity: 1 !important;
+  }
+
+  #zen-sidebar-splitter:hover {
+    background: #313244 !important;
+    background-color: #313244 !important;
+  }
+
+  /* macOS-specific variable overrides */
+  @media (-moz-platform: macos) {
+    :root {
+      --zen-themed-toolbar-bg-transparent: #181825 !important;
+      --zen-main-browser-background-toolbar: #181825 !important;
+      --zen-main-browser-background-old: #181825 !important;
+      --zen-main-browser-background-toolbar-old: #181825 !important;
+      --zen-navigator-toolbox-background: #181825 !important;
+    }
+  }
 }

--- a/themes/Mocha/Yellow/userChrome.css
+++ b/themes/Mocha/Yellow/userChrome.css
@@ -24,6 +24,8 @@
     --zen-themed-toolbar-bg: #181825 !important;
     --zen-main-browser-background: #181825 !important;
     --toolbox-bgcolor-inactive: #181825 !important;
+    --zen-element-separation: 8px !important;
+    --zen-webview-border-radius: 10px !important;
   }
 
   #permissions-granted-icon {
@@ -120,17 +122,42 @@
     --identity-icon-color: #cba6f7 !important;
   }
 
-  hbox#titlebar {
-    background-color: #181825 !important;
-  }
-
   #zen-appcontent-navbar-container {
     background-color: #181825 !important;
   }
 
-  /* ── Fix Zen Twilight acrylic/blur bleeding through wrapper gaps ── */
+  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  #sidebar-splitter,
+  #zen-sidebar-splitter {
+    --catppuccin-splitter-idle: #181825;
+    --catppuccin-splitter-hover-neutral: color-mix(
+      in srgb,
+      white 28%,
+      #181825 72%
+    );
+    border: none !important;
+    opacity: 1 !important;
+    background: var(--catppuccin-splitter-idle) !important;
+    background-color: var(--catppuccin-splitter-idle) !important;
+    transition:
+      background-color 0.18s ease-in-out,
+      background 0.18s ease-in-out,
+      opacity 0.18s ease-in-out !important;
+  }
 
-  /* Remove system appearance so CSS backgrounds take effect */
+  #sidebar-splitter::before,
+  #zen-sidebar-splitter::before {
+    display: none !important;
+    opacity: 0 !important;
+  }
+
+  #sidebar-splitter:hover,
+  #zen-sidebar-splitter:hover {
+    background: var(--catppuccin-splitter-hover-neutral) !important;
+    background-color: var(--catppuccin-splitter-hover-neutral) !important;
+  }
+
+  /* Wrapper appearance reset that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
   #zen-sidebar-splitter,
@@ -139,10 +166,9 @@
     -moz-default-appearance: none !important;
   }
 
-  /* Paint every wrapper / splitter / gap element with Catppuccin Mocha base */
+  /* Wrapper/background painting that proved safe in testing */
   #zen-main-app-wrapper,
   #zen-appcontent-wrapper,
-  #zen-sidebar-splitter,
   #zen-browser-background,
   .zen-browser-generic-background,
   .zen-toolbar-background,
@@ -153,32 +179,9 @@
     background-color: #181825 !important;
   }
 
-  /* Style sidebar splitters */
-  #sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-  }
-
-  #zen-sidebar-splitter {
-    border: none !important;
-    background: #181825 !important;
-    background-color: #181825 !important;
-    opacity: 1 !important;
-  }
-
-  #zen-sidebar-splitter:hover {
-    background: #313244 !important;
-    background-color: #313244 !important;
-  }
-
-  /* macOS-specific variable overrides */
-  @media (-moz-platform: macos) {
-    :root {
-      --zen-themed-toolbar-bg-transparent: #181825 !important;
-      --zen-main-browser-background-toolbar: #181825 !important;
-      --zen-main-browser-background-old: #181825 !important;
-      --zen-main-browser-background-toolbar-old: #181825 !important;
-      --zen-navigator-toolbox-background: #181825 !important;
-    }
+  /* Remove seam shadows that can show through at the sidebar/content corners */
+  #zen-tabbox-wrapper #sidebar-box,
+  #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
+    box-shadow: none !important;
   }
 }

--- a/themes/Mocha/Yellow/userChrome.css
+++ b/themes/Mocha/Yellow/userChrome.css
@@ -26,6 +26,14 @@
     --toolbox-bgcolor-inactive: #181825 !important;
     --zen-element-separation: 8px !important;
     --zen-webview-border-radius: 10px !important;
+    --catppuccin-quit-dialog-bg: #1e1e2e !important;
+    --catppuccin-quit-dialog-fg: #cdd6f4 !important;
+    --catppuccin-quit-dialog-accent: #f9e2af !important;
+    --catppuccin-quit-dialog-button-bg: #313244 !important;
+    --catppuccin-quit-dialog-button-bg-hover: #45475a !important;
+    --catppuccin-quit-dialog-button-bg-active: #585b70 !important;
+    --catppuccin-quit-dialog-button-border: #585b70 !important;
+    --catppuccin-quit-dialog-muted: #a6adc8 !important;
   }
 
   #permissions-granted-icon {
@@ -126,7 +134,9 @@
     background-color: #181825 !important;
   }
 
-  /* Safer Zen Twilight acrylic/seam fix based on a working macOS/Twilight setup */
+  /* Keep only the splitter themed; let Zen manage its own wrapper layers so
+   * detached compact mode preserves the native shell structure.
+   */
   #sidebar-splitter,
   #zen-sidebar-splitter {
     --catppuccin-splitter-idle: #181825;
@@ -179,9 +189,118 @@
     background-color: #181825 !important;
   }
 
+  /* Keep Zen's detached compact shell layered instead of painting every wrapper. */
+  :root[zen-compact-mode="true"] #navigator-toolbox:not([animate="true"]),
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    #titlebar,
+  :root[zen-compact-mode="true"] #TabsToolbar,
+  :root[zen-compact-mode="true"] #zen-appcontent-navbar-container {
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::before,
+  :root[zen-compact-mode="true"]
+    #navigator-toolbox:not([animate="true"])
+    .zen-toolbar-background::after {
+    background: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+    background-color: color-mix(
+      in srgb,
+      var(--lwt-sidebar-background-color) 82%,
+      black
+    ) !important;
+  }
+
   /* Remove seam shadows that can show through at the sidebar/content corners */
   #zen-tabbox-wrapper #sidebar-box,
   #tabbrowser-tabbox #tabbrowser-tabpanels .browserSidebarContainer {
     box-shadow: none !important;
+  }
+
+  /* Theme Firefox/Zen's common prompt dialogs, including the quit warning. */
+  @-moz-document url("chrome://global/content/commonDialog.xhtml") {
+    :root {
+      color-scheme: dark !important;
+      --focus-outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      --focus-outline-offset: 2px !important;
+    }
+
+    #commonDialog,
+    dialog,
+    dialog::part(content-box) {
+      appearance: none !important;
+      background: var(--catppuccin-quit-dialog-bg) !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #dialogGrid,
+    #infoContainer,
+    #iconContainer,
+    #checkboxContainer,
+    .dialogRow,
+    .dialogRow:not([hidden]) {
+      background: transparent !important;
+      color: inherit !important;
+    }
+
+    #infoTitle,
+    #infoBody,
+    description,
+    label,
+    checkbox,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-fg) !important;
+    }
+
+    #infoTitle {
+      font-weight: 700 !important;
+    }
+
+    #infoBody,
+    .checkbox-label {
+      color: var(--catppuccin-quit-dialog-muted) !important;
+    }
+
+    #infoIcon {
+      fill: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button) {
+      appearance: none !important;
+      -moz-appearance: none !important;
+      background: var(--catppuccin-quit-dialog-button-bg) !important;
+      background-image: none !important;
+      color: var(--catppuccin-quit-dialog-fg) !important;
+      border: 1px solid var(--catppuccin-quit-dialog-button-border) !important;
+      border-radius: 10px !important;
+      box-shadow: none !important;
+      text-shadow: none !important;
+      outline: none !important;
+    }
+
+    dialog::part(dialog-button):hover {
+      background: var(--catppuccin-quit-dialog-button-bg-hover) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):hover:active {
+      background: var(--catppuccin-quit-dialog-button-bg-active) !important;
+      border-color: var(--catppuccin-quit-dialog-accent) !important;
+    }
+
+    dialog::part(dialog-button):focus-visible {
+      outline: 2px solid var(--catppuccin-quit-dialog-accent) !important;
+      outline-offset: 2px !important;
+    }
   }
 }

--- a/themes/Mocha/Yellow/userContent.css
+++ b/themes/Mocha/Yellow/userContent.css
@@ -202,6 +202,12 @@
       color: #cdd6f4 !important;
     }
 
+    #categories > .category,
+    .sidebar-footer-link {
+      border-color: transparent !important;
+      box-shadow: none !important;
+    }
+
     #categories > .category:hover,
     .sidebar-footer-link:hover {
       background: #313244 !important;
@@ -210,6 +216,7 @@
     #categories > .category[selected],
     #categories > .category.selected {
       color: #f9e2af !important;
+      border-color: transparent !important;
     }
 
     groupbox,

--- a/themes/Mocha/Yellow/userContent.css
+++ b/themes/Mocha/Yellow/userContent.css
@@ -63,67 +63,326 @@
   /* Variables and styles specific to about:preferences */
   @-moz-document url-prefix("about:preferences") {
     :root {
-      --zen-colors-tertiary: #181825 !important;
-      --in-content-text-color: #cdd6f4 !important;
+      --background-color-canvas: #11111b !important;
+      --background-color-box: #1e1e2e !important;
+      --background-color-box-info: #313244 !important;
+      --background-color-critical: color-mix(in srgb, #f38ba8 18%, #1e1e2e) !important;
+      --background-color-information: color-mix(in srgb, #89b4fa 18%, #1e1e2e) !important;
+      --background-color-list-item-hover: color-mix(in srgb, #f9e2af 18%, transparent) !important;
+      --background-color-list-item-selected: color-mix(in srgb, #f9e2af 26%, #313244) !important;
+      --background-color-success: color-mix(in srgb, #a6e3a1 18%, #1e1e2e) !important;
+      --background-color-warning: color-mix(in srgb, #f9e2af 18%, #1e1e2e) !important;
+      --border-color: #45475a !important;
+      --border-color-deemphasized: #313244 !important;
+      --border-color-interactive: #585b70 !important;
+      --border-color-interactive-hover: #6c7086 !important;
+      --border-color-interactive-active: #7f849c !important;
+      --border-color-selected: #f9e2af !important;
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-background-color-selected: color-mix(in srgb, #f9e2af 24%, #313244) !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+      --button-background-color: #313244 !important;
+      --button-background-color-hover: #45475a !important;
+      --button-background-color-active: #585b70 !important;
+      --button-background-color-selected: color-mix(in srgb, #f9e2af 24%, #313244) !important;
+      --button-background-color-primary: #f9e2af !important;
+      --button-background-color-primary-hover: color-mix(in srgb, #f9e2af 86%, #cdd6f4) !important;
+      --button-background-color-primary-active: color-mix(in srgb, #f9e2af 94%, #1e1e2e) !important;
+      --button-border-color: #45475a !important;
+      --button-border-color-hover: #585b70 !important;
+      --button-border-color-active: #f9e2af !important;
+      --button-border-color-primary: #f9e2af !important;
+      --button-text-color: #cdd6f4 !important;
+      --button-text-color-hover: #cdd6f4 !important;
+      --button-text-color-active: #cdd6f4 !important;
+      --button-text-color-primary: #11111b !important;
+      --button-text-color-primary-hover: #11111b !important;
+      --button-text-color-primary-active: #11111b !important;
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+      --color-accent-primary: #f9e2af !important;
+      --color-accent-primary-hover: rgb(251, 234, 199) !important;
+      --color-accent-primary-active: rgb(249, 244, 175) !important;
+      --focus-outline-color: #f9e2af !important;
+      --icon-color: #bac2de !important;
+      --icon-color-critical: #f38ba8 !important;
+      --icon-color-information: #89b4fa !important;
+      --icon-color-success: #a6e3a1 !important;
+      --icon-color-warning: #f9e2af !important;
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
       --link-color: #f9e2af !important;
+      --link-color-active: rgb(249, 244, 175) !important;
       --link-color-hover: rgb(251, 234, 199) !important;
-      --zen-colors-primary: #313244 !important;
+      --link-color-visited: #cba6f7 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f9e2af !important;
+      --select-text-color: #cdd6f4 !important;
+      --table-row-background-color-alternate: #181825 !important;
+      --table-row-background-color-hover: #313244 !important;
+      --table-row-background-color-selected: color-mix(in srgb, #f9e2af 24%, #313244) !important;
+      --text-color: #cdd6f4 !important;
+      --text-color-deemphasized: #bac2de !important;
+      --text-color-disabled: #6c7086 !important;
+      --text-color-error: #f38ba8 !important;
+      --text-color-success: #a6e3a1 !important;
+      --text-color-warning: #f9e2af !important;
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f9e2af !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f9e2af 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f9e2af 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f9e2af !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+      --zen-colors-tertiary: #181825 !important;
+      --zen-colors-border: #45475a !important;
+      --zen-colors-hover-bg: #313244 !important;
+      --in-content-text-color: #cdd6f4 !important;
+      --in-content-page-background: #11111b !important;
+      --in-content-page-color: #cdd6f4 !important;
       --in-content-box-background: #313244 !important;
+      --in-content-box-background-odd: #181825 !important;
+      --in-content-box-border-color: #45475a !important;
+      --in-content-border-color: #45475a !important;
+      --in-content-button-background: #313244 !important;
+      --in-content-button-background-hover: #45475a !important;
+      --in-content-button-background-active: #585b70 !important;
+      --in-content-button-border-color: #45475a !important;
+      --in-content-button-border-color-hover: #585b70 !important;
+      --in-content-button-border-color-active: #f9e2af !important;
+      --in-content-button-text-color: #cdd6f4 !important;
+      --in-content-deemphasized-text: #bac2de !important;
+      --in-content-item-hover: #313244 !important;
+      --in-content-item-selected: color-mix(in srgb, #f9e2af 22%, #313244) !important;
+      --in-content-primary-button-background: #f9e2af !important;
+      --in-content-primary-button-background-hover: color-mix(in srgb, #f9e2af 86%, #cdd6f4) !important;
+      --in-content-primary-button-background-active: color-mix(in srgb, #f9e2af 94%, #1e1e2e) !important;
+      --in-content-primary-button-text-color: #11111b !important;
+      --zen-colors-primary: #313244 !important;
       --zen-primary-color: #f9e2af !important;
     }
 
-    groupbox , moz-card{
-      background: #1e1e2e !important;
-    }
-
-    button,
-    groupbox menulist {
-      background: #313244 !important;
+    html,
+    body,
+    #preferences-root,
+    #preferences-body,
+    #preferences-stack,
+    .main-content,
+    .pane-container,
+    .sticky-container,
+    .sticky-inner-container {
+      background: #11111b !important;
       color: #cdd6f4 !important;
     }
 
-    .main-content {
-      background-color: #11111b !important;
+    .navigation {
+      background: #181825 !important;
+      color: #cdd6f4 !important;
+    }
+
+    #categories > .category:hover,
+    .sidebar-footer-link:hover {
+      background: #313244 !important;
+    }
+
+    #categories > .category[selected],
+    #categories > .category.selected {
+      color: #f9e2af !important;
+    }
+
+    groupbox,
+    moz-card {
+      background: #1e1e2e !important;
+      border: 1px solid #45475a !important;
+      box-shadow: none !important;
+      color: #cdd6f4 !important;
+    }
+
+    groupbox.highlighting-group {
+      padding: var(--space-large) !important;
+    }
+
+    moz-card {
+      --card-background-color: #1e1e2e !important;
+      --card-border-color: #45475a !important;
+      --card-box-shadow: none !important;
+      --card-box-shadow-hover: 0 0 0 1px #585b70 !important;
+    }
+
+    moz-box-group,
+    moz-box-item,
+    moz-box-link,
+    moz-box-button {
+      --box-background-color: #1e1e2e !important;
+      --box-border-color: #45475a !important;
+      --box-button-background-color: #313244 !important;
+      --box-button-background-color-hover: #45475a !important;
+      --box-button-background-color-active: #585b70 !important;
+      --box-button-text-color: #cdd6f4 !important;
+      --box-icon-color: #bac2de !important;
+    }
+
+    moz-input-search,
+    moz-input-text,
+    moz-select {
+      --input-text-background-color: #181825 !important;
+      --input-text-border-color: #585b70 !important;
+      --input-text-color: #cdd6f4 !important;
+      --input-text-placeholder-color: #a6adc8 !important;
+      --select-background-color: #313244 !important;
+      --select-background-color-hover: #45475a !important;
+      --select-background-color-active: #585b70 !important;
+      --select-border-color: #45475a !important;
+      --select-border-color-hover: #585b70 !important;
+      --select-border-color-active: #f9e2af !important;
+      --select-text-color: #cdd6f4 !important;
+    }
+
+    moz-toggle {
+      --toggle-background-color: #45475a !important;
+      --toggle-background-color-hover: #585b70 !important;
+      --toggle-background-color-pressed: #f9e2af !important;
+      --toggle-background-color-pressed-hover: color-mix(in srgb, #f9e2af 86%, #cdd6f4) !important;
+      --toggle-dot-background-color: #cdd6f4 !important;
+      --toggle-dot-background-color-on-pressed: #11111b !important;
+    }
+
+    moz-visual-picker-item {
+      --visual-picker-item-background-color: #1e1e2e !important;
+      --visual-picker-item-background-color-hover: #313244 !important;
+      --visual-picker-item-background-color-active: #45475a !important;
+      --visual-picker-item-background-color-selected: color-mix(in srgb, #f9e2af 16%, #313244) !important;
+      --visual-picker-item-border-color: #45475a !important;
+      --visual-picker-item-border-color-hover: #585b70 !important;
+      --visual-picker-item-border-color-selected: #f9e2af !important;
+      --visual-picker-item-check-icon-color: #11111b !important;
+      --visual-picker-item-icon-color: #bac2de !important;
+      --visual-picker-item-text-color: #cdd6f4 !important;
+    }
+
+    button,
+    groupbox menulist,
+    groupbox select {
+      background: #313244 !important;
+      color: #cdd6f4 !important;
+      border-color: #45475a !important;
+    }
+
+    button:not([disabled]):hover,
+    groupbox menulist:not([disabled]):hover,
+    groupbox select:not([disabled]):hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    button:not([disabled]):hover:active,
+    groupbox menulist[open="true"],
+    groupbox select:active {
+      background: #585b70 !important;
+      border-color: #f9e2af !important;
+    }
+
+    .zenCKSOption-input {
+      background: #313244 !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenCKSOption-input:hover {
+      background: #45475a !important;
+      border-color: #585b70 !important;
+    }
+
+    .zenCKSOption-input.zenCKSOption-input-editing {
+      background: #181825 !important;
+      border-color: #f9e2af !important;
+      box-shadow: 0 0 0 2px color-mix(in srgb, #f9e2af 35%, transparent) !important;
+    }
+
+    #zenCKSOption-wrapper > [data-group] {
+      border-bottom-color: #313244 !important;
+    }
+
+    #zen-theme-builder,
+    .zenThemeMarketplaceItem {
+      background: #1e1e2e !important;
+      border-color: #45475a !important;
+      color: #cdd6f4 !important;
+    }
+
+    .zenThemeMarketplaceItem:hover {
+      background: #313244 !important;
+      border-color: #585b70 !important;
+    }
+
+    #zenLayoutList > [layout] img {
+      border-color: #313244 !important;
+    }
+
+    #zenLayoutList > [layout].selected img {
+      border-color: #f9e2af !important;
     }
 
     .identity-color-blue {
-      --identity-tab-color: #8aadf4 !important;
-      --identity-icon-color: #8aadf4 !important;
+      --identity-tab-color: #89b4fa !important;
+      --identity-icon-color: #89b4fa !important;
     }
 
     .identity-color-turquoise {
-      --identity-tab-color: #8bd5ca !important;
-      --identity-icon-color: #8bd5ca !important;
+      --identity-tab-color: #94e2d5 !important;
+      --identity-icon-color: #94e2d5 !important;
     }
 
     .identity-color-green {
-      --identity-tab-color: #a6da95 !important;
-      --identity-icon-color: #a6da95 !important;
+      --identity-tab-color: #a6e3a1 !important;
+      --identity-icon-color: #a6e3a1 !important;
     }
 
     .identity-color-yellow {
-      --identity-tab-color: #eed49f !important;
-      --identity-icon-color: #eed49f !important;
+      --identity-tab-color: #f9e2af !important;
+      --identity-icon-color: #f9e2af !important;
     }
 
     .identity-color-orange {
-      --identity-tab-color: #f5a97f !important;
-      --identity-icon-color: #f5a97f !important;
+      --identity-tab-color: #fab387 !important;
+      --identity-icon-color: #fab387 !important;
     }
 
     .identity-color-red {
-      --identity-tab-color: #ed8796 !important;
-      --identity-icon-color: #ed8796 !important;
+      --identity-tab-color: #f38ba8 !important;
+      --identity-icon-color: #f38ba8 !important;
     }
 
     .identity-color-pink {
-      --identity-tab-color: #f5bde6 !important;
-      --identity-icon-color: #f5bde6 !important;
+      --identity-tab-color: #f5c2e7 !important;
+      --identity-icon-color: #f5c2e7 !important;
     }
 
     .identity-color-purple {
-      --identity-tab-color: #c6a0f6 !important;
-      --identity-icon-color: #c6a0f6 !important;
+      --identity-tab-color: #cba6f7 !important;
+      --identity-icon-color: #cba6f7 !important;
     }
   }
 


### PR DESCRIPTION
## Problem

Recent Zen Browser Twilight updates apply system-level acrylic/blur via the `appearance` property on UI wrapper elements. This causes the system/window background to bleed through gaps between the sidebar and content panels, breaking Catppuccin theming — a visible unstyled strip appears between the side panel and content area.

## Fix

For **all 4 flavors × 14 accent variants** (56 files):

- **`appearance: unset`** on `#zen-main-app-wrapper`, `#zen-appcontent-wrapper`, `#zen-sidebar-splitter`, and `#zen-browser-background` — disables the acrylic effect so CSS backgrounds take effect
- **Explicit background** on all wrapper / splitter / gap elements with each flavor's Catppuccin base color
- **Sidebar splitter styling** — matches base color at rest, highlights to surface0 on hover
- **macOS-specific variable overrides** for Zen toolbar transparency variables

### Flavor colors used

| Flavor | Base (gap bg) | Surface0 (hover) |
|---|---|---|
| 🌻 Latte | `#e6e9ef` | `#ccd0da` |
| 🪴 Frappé | `#292c3c` | `#414559` |
| 🌺 Macchiato | `#1e2030` | `#363a4f` |
| 🌿 Mocha | `#181825` | `#313244` |

## Testing

Tested on macOS with Zen Browser Twilight (Frappé Blue). The gap between sidebar and content now correctly shows the Catppuccin base color, and the content panel border radius / separation is preserved at Zen defaults.